### PR TITLE
Fix FPQR solid module animation

### DIFF
--- a/fpqr/js/renderer.js
+++ b/fpqr/js/renderer.js
@@ -335,7 +335,7 @@ function renderCanvas() {
             }); });
         }
 
-        const solidPath = new Path2D();
+        const batchSolidPath = shape === 'solid' && !isAnimated ? new Path2D() : null;
 
         // CHARACTER MODE
         // Rasterize glyph once via getGlyphSprite(), then stamp with drawImage().
@@ -431,7 +431,9 @@ function renderCanvas() {
                 }
 
                 if (shape === 'solid') {
-                    roundRectPath(solidPath, cx, cy, cell + 0.5, cell + 0.5, Math.max(0, (cell/2)*(dB/100)));
+                    const solidTarget = batchSolidPath || ctx;
+                    roundRectPath(solidTarget, cx, cy, cell + 0.5, cell + 0.5, Math.max(0, (cell/2)*(dB/100)));
+                    if (!batchSolidPath) ctx.fill();
                 } else if (shape === 'organic') {
                     const rad = Math.max(0, (cell/2)*(dB/100));
                     const t = shouldRenderData(r-1,c), b = shouldRenderData(r+1,c), l = shouldRenderData(r,c-1), ri = shouldRenderData(r,c+1);
@@ -483,9 +485,9 @@ function renderCanvas() {
             }
         }
             // Flush all solid modules in one GPU draw call
-            if (shape === 'solid') {
+            if (batchSolidPath) {
                 ctx.fillStyle = heatmap ? ctx.fillStyle : fgGrad;
-                ctx.fill(solidPath);
+                ctx.fill(batchSolidPath);
             }
         } // end shape branch
 


### PR DESCRIPTION
### Motivation
- The default "solid" module path was being batched into a single `Path2D` regardless of animation state, which prevented per-module `translate`/`scale` transforms from taking effect and caused the animation to appear static.

### Description
- Change `fpqr/js/renderer.js` to create a `batchSolidPath` only when `shape === 'solid' && !isAnimated` so batching is skipped during animation.
- When drawing solid modules use `const solidTarget = batchSolidPath || ctx` and call `ctx.fill()` for per-module drawing when not batching, allowing animated modules to be transformed individually.
- Preserve the optimized single `Path2D` fill for non-animated solid rendering to retain the original performance win.

### Testing
- Ran `node --check fpqr/js/renderer.js` and it succeeded.
- Ran `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eebdc165c83269f45d21f9a6a1f99)