### PR TITLE
Improve animated preview performance and scannability checks; batch solid module rendering when static

### DIFF
--- a/fpqr/js/qr-engine.js
+++ b/fpqr/js/qr-engine.js
@@ -185,8 +185,9 @@ function checkScannability() {
     if (!optCan || !container) return;
 
     const targetStr = currentMatrices.res.finalString;
+    const isAnimated = E('anim-toggle')?.checked || (typeof getHasAnimatedGif === 'function' && getHasAnimatedGif());
     let score = 0;
-    const s = 512;
+    const s = isAnimated ? 256 : 512;
 
     const drawAndTest = (transformFn, filterStr = 'none') => {
         validateCtx.fillStyle = '#ffffff';
@@ -206,19 +207,20 @@ function checkScannability() {
     };
 
     if (drawAndTest()) {
-        score += 40; 
-        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.8, 0.8); ctx.translate(-s/2, -s/2); })) score += 15;
-        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.6, 0.6); ctx.translate(-s/2, -s/2); })) score += 15;
-        if (drawAndTest(null, 'blur(0.5px)')) score += 15;
-        if (drawAndTest(null, 'blur(1px)')) score += 15;
+        score += isAnimated ? 70 : 40;
+        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.8, 0.8); ctx.translate(-s/2, -s/2); })) score += isAnimated ? 30 : 15;
+        if (!isAnimated) {
+            if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.6, 0.6); ctx.translate(-s/2, -s/2); })) score += 15;
+            if (drawAndTest(null, 'blur(0.5px)')) score += 15;
+            if (drawAndTest(null, 'blur(1px)')) score += 15;
+        }
     } else {
-        if (drawAndTest(null, 'contrast(400%) grayscale(100%)')) { score += 20; } 
-        else if (drawAndTest(null, 'brightness(200%) contrast(400%) grayscale(100%)')) { score += 20; } 
-        else if (drawAndTest(null, 'brightness(50%) contrast(400%) grayscale(100%)')) { score += 20; }
-        else if (drawAndTest(null, 'invert(100%) contrast(400%) grayscale(100%)')) { score += 20; }
+        if (drawAndTest(null, 'contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'brightness(200%) contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'brightness(50%) contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'invert(100%) contrast(400%) grayscale(100%)')) { score += 20; }
     }
 
-    const isAnimated = E('anim-toggle')?.checked || (typeof getHasAnimatedGif === 'function' && getHasAnimatedGif());
 
     const updateBadge = (scoreNum, text, barColorClass, textColorClass) => {
         const bar = E('scan-score-bar');

--- a/fpqr/js/renderer.js
+++ b/fpqr/js/renderer.js
@@ -335,7 +335,7 @@ function renderCanvas() {
             }); });
         }
 
-        const solidPath = new Path2D();
+        const batchSolidPath = shape === 'solid' && !isAnimated ? new Path2D() : null;
 
         // CHARACTER MODE
         // Rasterize glyph once via getGlyphSprite(), then stamp with drawImage().
@@ -431,7 +431,9 @@ function renderCanvas() {
                 }
 
                 if (shape === 'solid') {
-                    roundRectPath(solidPath, cx, cy, cell + 0.5, cell + 0.5, Math.max(0, (cell/2)*(dB/100)));
+                    const solidTarget = batchSolidPath || ctx;
+                    roundRectPath(solidTarget, cx, cy, cell + 0.5, cell + 0.5, Math.max(0, (cell/2)*(dB/100)));
+                    if (!batchSolidPath) ctx.fill();
                 } else if (shape === 'organic') {
                     const rad = Math.max(0, (cell/2)*(dB/100));
                     const t = shouldRenderData(r-1,c), b = shouldRenderData(r+1,c), l = shouldRenderData(r,c-1), ri = shouldRenderData(r,c+1);
@@ -483,9 +485,9 @@ function renderCanvas() {
             }
         }
             // Flush all solid modules in one GPU draw call
-            if (shape === 'solid') {
+            if (batchSolidPath) {
                 ctx.fillStyle = heatmap ? ctx.fillStyle : fgGrad;
-                ctx.fill(solidPath);
+                ctx.fill(batchSolidPath);
             }
         } // end shape branch
 
@@ -595,5 +597,33 @@ function startAnimIfNeeded() {
     }
 }
 
-// Poll scannability independently at 500ms — decoupled from the 60fps render loop
-setInterval(checkScannability, 500);
+// Poll scannability independently from the 60fps render loop. jsQR reads back
+// canvas pixels synchronously, so running it every 500ms while the mesh is
+// animating creates a visible cadence hitch. Static previews keep the fast
+// scan cadence; animated previews scan less often and prefer idle time.
+let scanPollPending = false;
+let lastScanPollTime = 0;
+
+function scheduleScannabilityCheck() {
+    if (scanPollPending || typeof checkScannability !== 'function') return;
+
+    const isAnimatedPreview = E('anim-toggle')?.checked || getHasAnimatedGif();
+    const pollDelay = isAnimatedPreview ? 2500 : 500;
+    const now = performance.now();
+    if (now - lastScanPollTime < pollDelay) return;
+
+    scanPollPending = true;
+    const runScan = () => {
+        scanPollPending = false;
+        lastScanPollTime = performance.now();
+        checkScannability();
+    };
+
+    if ('requestIdleCallback' in window) {
+        requestIdleCallback(runScan, { timeout: isAnimatedPreview ? 2000 : 500 });
+    } else {
+        setTimeout(runScan, isAnimatedPreview ? 250 : 0);
+    }
+}
+
+setInterval(scheduleScannabilityCheck, 250);


### PR DESCRIPTION
### Motivation
- Reduce scan-time jank when the QR mesh is animating and make scannability scoring more appropriate for animated GIF previews.
- Reduce GPU draw calls for static renders by batching solid modules into a single Path2D.
- Make scannability polling adaptive to animation state to avoid frequent synchronous canvas reads during animation.

### Description
- Update `checkScannability()` to detect animated previews earlier, use a smaller test canvas (`s = 256`) for animated content, and change scoring weights and which filter/transform tests run for animated vs static previews.
- Move the `isAnimated` detection up in `checkScannability()` so it influences test size, scoring, and which filters are applied.
- In `renderCanvas()`, create `batchSolidPath` for shape === 'solid' when not animated and accumulate solid module geometry into a `Path2D`, then draw it once with `ctx.fill(batchSolidPath)`, falling back to per-module `ctx.fill()` when animated or batching is disabled.
- Replace the fixed `setInterval(checkScannability, 500)` with a smarter `scheduleScannabilityCheck()` loop that adapts its poll delay based on whether the preview is animated, uses `requestIdleCallback` when available, and rate-limits scans to reduce visible cadence hitching; polling runs via `setInterval(scheduleScannabilityCheck, 250)`.

### Testing
- Ran `npm test` and all automated unit tests passed.
- Ran `npm run lint` and code style checks passed.
- Built the project with `npm run build` and the bundle completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eebdc165c83269f45d21f9a6a1f99)