### PR TITLE
Improve color/gradient controls, finder customization, scannability polling, and rendering performance

### DIFF
--- a/fpqr/index.html
+++ b/fpqr/index.html
@@ -128,9 +128,18 @@
                         </select>
 
                         <div id="custom-module-container" class="hidden flex flex-col gap-3 bg-[#13151f] px-3 py-3 rounded-lg border border-dashed border-slate-700">
-                            <div id="module-char-container" class="hidden flex items-center justify-between">
-                                <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Character / Emoji</span>
-                                <input type="text" id="module-char" value="&#9733;" maxlength="3" class="bg-[#0f111a] border border-slate-700 outline-none rounded text-sm text-white px-2 py-1 w-16 text-center render-trigger">
+                            <div id="module-char-container" class="hidden flex flex-col gap-3">
+                                <div class="flex items-center justify-between">
+                                    <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Character / Emoji</span>
+                                    <input type="text" id="module-char" value="&#9733;" maxlength="3" class="bg-[#0f111a] border border-slate-700 outline-none rounded text-sm text-white px-2 py-1 w-16 text-center render-trigger">
+                                </div>
+                                <div class="flex items-center justify-between">
+                                    <span class="text-[10px] font-bold text-slate-500 uppercase">Force foreground color</span>
+                                    <label class="relative inline-flex items-center cursor-pointer m-0">
+                                        <input type="checkbox" id="module-char-colorize" class="sr-only peer render-trigger">
+                                        <div class="w-7 h-3.5 shrink-0 bg-slate-700 rounded-full peer peer-checked:bg-indigo-500 after:content-[''] after:absolute after:top-[1px] after:left-[1px] after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:after:translate-x-3.5"></div>
+                                    </label>
+                                </div>
                             </div>
                             <div id="module-image-container" class="hidden flex items-center justify-between">
                                 <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Image Source</span>
@@ -151,24 +160,26 @@
                                     <div class="flex items-center gap-1.5">
                                         <span class="text-[10px] font-bold text-slate-500">BG</span>
                                         <input type="color" id="color-bg-start" value="#ffffff" class="render-trigger">
-                                        <span class="text-slate-600 text-xs">&rarr;</span>
-                                        <input type="color" id="color-bg-end" value="#ffffff" class="render-trigger">
+                                        <span data-gradient-arrow class="text-slate-600 text-xs hidden">&rarr;</span>
+                                        <input type="color" id="color-bg-end" value="#ffffff" class="render-trigger hidden">
                                     </div>
                                     <div class="w-px h-5 bg-slate-700"></div>
                                     <div class="flex items-center gap-1.5 transition-opacity" id="fg-color-container">
                                         <span class="text-[10px] font-bold text-slate-500">FG</span>
                                         <input type="color" id="color-start" value="#000000" class="render-trigger">
-                                        <span class="text-slate-600 text-xs">&rarr;</span>
-                                        <input type="color" id="color-end" value="#000000" class="render-trigger">
+                                        <span data-gradient-arrow class="text-slate-600 text-xs hidden">&rarr;</span>
+                                        <input type="color" id="color-end" value="#000000" class="render-trigger hidden">
                                     </div>
                                 </div>
                             </div>
                             <div class="flex items-center gap-3 mt-1">
                                 <select id="grad-style" class="bg-slate-800 border-none outline-none rounded text-[10px] text-white px-2 py-1.5 font-bold uppercase render-trigger cursor-pointer">
-                                    <option value="linear">Linear</option>
-                                    <option value="radial">Radial</option>
-                                    <option value="image">Image Mask</option>
+                                    <option value="solid" selected>Solid</option>
+                                    <option value="linear">Linear Gradient</option>
+                                    <option value="radial">Radial Gradient</option>
+                                    <option value="image">Image Color Map</option>
                                 </select>
+                                <button id="invert-colors" type="button" class="text-[10px] bg-slate-800 hover:bg-slate-700 text-slate-200 px-2 py-1.5 rounded font-bold uppercase tracking-wider">Invert</button>
                                 <div class="flex items-center gap-2 flex-1 transition-opacity" id="grad-control-container">
                                     <div id="grad-angle-wrapper" class="flex items-center gap-2 flex-1 w-full">
                                         <svg class="w-3.5 h-3.5 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>
@@ -295,12 +306,23 @@
                                 </div>
                             </div>
                             <div>
-                                <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Outer Curves</span><span id="frame-bevel-val" class="text-white font-mono">50%</span></div>
+                                <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Finder Frame Radius</span><span id="frame-bevel-val" class="text-white font-mono">50%</span></div>
                                 <input type="range" id="frame-bevel" min="0" max="100" value="50" class="w-full render-trigger">
                             </div>
                             <div>
-                                <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Inner Curves</span><span id="pupil-bevel-val" class="text-white font-mono">50%</span></div>
+                                <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Finder Center Radius</span><span id="pupil-bevel-val" class="text-white font-mono">50%</span></div>
                                 <input type="range" id="pupil-bevel" min="0" max="100" value="50" class="w-full render-trigger">
+                            </div>
+                            <div class="grid grid-cols-2 gap-3">
+                                <label class="flex items-center justify-between text-[10px] font-bold text-slate-500 uppercase">Frame <input type="color" id="finder-frame-color" value="#000000" class="render-trigger"></label>
+                                <label class="flex items-center justify-between text-[10px] font-bold text-slate-500 uppercase">Center <input type="color" id="finder-pupil-color" value="#000000" class="render-trigger"></label>
+                            </div>
+                            <div class="flex items-center justify-between border-t border-slate-800 pt-3">
+                                <span class="text-[10px] font-bold text-slate-500 uppercase">Center style</span>
+                                <select id="finder-pupil-mode" class="bg-slate-800 border-none outline-none rounded text-[10px] text-white px-2 py-1.5 font-bold uppercase render-trigger cursor-pointer">
+                                    <option value="big" selected>One block</option>
+                                    <option value="modules">3x3 modules</option>
+                                </select>
                             </div>
                         </div>
 
@@ -341,12 +363,16 @@
                             </div>
                             <div id="align-sliders" class="space-y-4 opacity-30 pointer-events-none transition-opacity">
                                 <div>
-                                    <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Outer Curves</span><span id="align-frame-bevel-val" class="text-white font-mono">50%</span></div>
+                                    <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Alignment Frame Radius</span><span id="align-frame-bevel-val" class="text-white font-mono">50%</span></div>
                                     <input type="range" id="align-frame-bevel" min="0" max="100" value="50" class="w-full render-trigger">
                                 </div>
                                 <div>
-                                    <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Inner Curves</span><span id="align-pupil-bevel-val" class="text-white font-mono">50%</span></div>
+                                    <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Alignment Center Radius</span><span id="align-pupil-bevel-val" class="text-white font-mono">50%</span></div>
                                     <input type="range" id="align-pupil-bevel" min="0" max="100" value="50" class="w-full render-trigger">
+                                </div>
+                                <div class="grid grid-cols-2 gap-3">
+                                    <label class="flex items-center justify-between text-[10px] font-bold text-slate-500 uppercase">Frame <input type="color" id="align-frame-color" value="#000000" class="render-trigger"></label>
+                                    <label class="flex items-center justify-between text-[10px] font-bold text-slate-500 uppercase">Center <input type="color" id="align-pupil-color" value="#000000" class="render-trigger"></label>
                                 </div>
                             </div>
                         </div>
@@ -510,7 +536,7 @@
                             </label>
                         </div>
 
-                        <div class="bg-white p-3 rounded-2xl shadow-2xl border border-emerald-500/30 relative overflow-hidden flex items-center justify-center w-full max-w-[320px] aspect-square" id="opt-container">
+                        <div class="bg-white p-1 rounded-2xl shadow-2xl border border-emerald-500/30 relative overflow-hidden flex items-center justify-center w-full max-w-[320px] aspect-square" id="opt-container">
                             <canvas id="qr-optimal" style="width: 100%; height: 100%;" class="max-w-full"></canvas>
                             
                             <div id="gif-progress" class="hidden absolute inset-0 bg-[#0f111a]/90 backdrop-blur-sm flex flex-col items-center justify-center z-30">

--- a/fpqr/js/app.js
+++ b/fpqr/js/app.js
@@ -210,6 +210,10 @@ const initApp = () => {
         E('density-map-upload-container')?.classList.toggle('hidden', dms !== 'image');
         E('fg-color-container')?.classList.toggle('opacity-30', gs === 'image');
         E('fg-color-container')?.classList.toggle('pointer-events-none', gs === 'image');
+        const isGradient = gs === 'linear' || gs === 'radial';
+        E('color-bg-end')?.classList.toggle('hidden', !isGradient);
+        E('color-end')?.classList.toggle('hidden', !isGradient);
+        document.querySelectorAll('[data-gradient-arrow]').forEach(el => el.classList.toggle('hidden', !isGradient));
         if (gs === 'image' && !colorMapImage) genDefaultImageMap('color');
         if (dms === 'image' && !densityMapImage) genDefaultImageMap('density');
     }
@@ -243,7 +247,7 @@ const initApp = () => {
                 E('module-char-container')?.classList.toggle('hidden', !isChar);
                 E('module-image-container')?.classList.toggle('hidden', !isImg);
                 const gs = E('grad-style')?.value;
-                E('grad-angle-wrapper')?.classList.toggle('hidden', gs === 'radial' || gs === 'image');
+                E('grad-angle-wrapper')?.classList.toggle('hidden', gs !== 'linear');
                 E('grad-radial-wrapper')?.classList.toggle('hidden', gs !== 'radial');
                 updateImageMapVisibility();
                 if (E('anim-toggle')?.checked) {
@@ -366,9 +370,18 @@ const initApp = () => {
         const val = e.target.value;
         const isRadial = val === 'radial';
         const isImage = val === 'image';
-        E('grad-angle-wrapper')?.classList.toggle('hidden', isRadial || isImage);
+        E('grad-angle-wrapper')?.classList.toggle('hidden', val !== 'linear');
         E('grad-radial-wrapper')?.classList.toggle('hidden', !isRadial);
         updateImageMapVisibility();
+        renderCanvas();
+    });
+
+    E('invert-colors')?.addEventListener('click', () => {
+        const bgStart = E('color-bg-start'), bgEnd = E('color-bg-end');
+        const fgStart = E('color-start'), fgEnd = E('color-end');
+        if (!bgStart || !bgEnd || !fgStart || !fgEnd) return;
+        [bgStart.value, fgStart.value] = [fgStart.value, bgStart.value];
+        [bgEnd.value, fgEnd.value] = [fgEnd.value, bgEnd.value];
         renderCanvas();
     });
 

--- a/fpqr/js/qr-engine.js
+++ b/fpqr/js/qr-engine.js
@@ -185,8 +185,9 @@ function checkScannability() {
     if (!optCan || !container) return;
 
     const targetStr = currentMatrices.res.finalString;
+    const isAnimated = E('anim-toggle')?.checked || (typeof getHasAnimatedGif === 'function' && getHasAnimatedGif());
     let score = 0;
-    const s = 512;
+    const s = isAnimated ? 256 : 512;
 
     const drawAndTest = (transformFn, filterStr = 'none') => {
         validateCtx.fillStyle = '#ffffff';
@@ -206,19 +207,20 @@ function checkScannability() {
     };
 
     if (drawAndTest()) {
-        score += 40; 
-        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.8, 0.8); ctx.translate(-s/2, -s/2); })) score += 15;
-        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.6, 0.6); ctx.translate(-s/2, -s/2); })) score += 15;
-        if (drawAndTest(null, 'blur(0.5px)')) score += 15;
-        if (drawAndTest(null, 'blur(1px)')) score += 15;
+        score += isAnimated ? 70 : 40;
+        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.8, 0.8); ctx.translate(-s/2, -s/2); })) score += isAnimated ? 30 : 15;
+        if (!isAnimated) {
+            if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.6, 0.6); ctx.translate(-s/2, -s/2); })) score += 15;
+            if (drawAndTest(null, 'blur(0.5px)')) score += 15;
+            if (drawAndTest(null, 'blur(1px)')) score += 15;
+        }
     } else {
-        if (drawAndTest(null, 'contrast(400%) grayscale(100%)')) { score += 20; } 
-        else if (drawAndTest(null, 'brightness(200%) contrast(400%) grayscale(100%)')) { score += 20; } 
-        else if (drawAndTest(null, 'brightness(50%) contrast(400%) grayscale(100%)')) { score += 20; }
-        else if (drawAndTest(null, 'invert(100%) contrast(400%) grayscale(100%)')) { score += 20; }
+        if (drawAndTest(null, 'contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'brightness(200%) contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'brightness(50%) contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'invert(100%) contrast(400%) grayscale(100%)')) { score += 20; }
     }
 
-    const isAnimated = E('anim-toggle')?.checked || (typeof getHasAnimatedGif === 'function' && getHasAnimatedGif());
 
     const updateBadge = (scoreNum, text, barColorClass, textColorClass) => {
         const bar = E('scan-score-bar');

--- a/fpqr/js/renderer.js
+++ b/fpqr/js/renderer.js
@@ -77,7 +77,8 @@ function getCurrentGifFrame(gifData, timeMs) {
 }
 
 function createEngineGradient(ctx, cSz, c1, c2) {
-    const gradStyle = E('grad-style')?.value || 'linear';
+    const gradStyle = E('grad-style')?.value || 'solid';
+    if (gradStyle === 'solid' || gradStyle === 'image' || c1 === c2) return c1;
     let grad;
     if (gradStyle === 'radial') {
         const rScale = parseInt(E('grad-radial')?.value || '100') / 100;
@@ -115,8 +116,8 @@ function getMapData(activeImage, gSz, ctx, canvas) {
 // Rasterizes the character once onto an offscreen canvas; every module then
 // uses drawImage() instead of fillText(), which is much faster on iOS Safari.
 // Cache key: char + cellSize + color + bevel -- any change triggers a rebuild.
-function getGlyphSprite(char, cell, color, bevel) {
-    const key = char + '|' + Math.round(cell) + '|' + color + '|' + bevel;
+function getGlyphSprite(char, cell, color, bevel, colorize) {
+    const key = char + '|' + Math.round(cell) + '|' + color + '|' + bevel + '|' + colorize;
     if (glyphCache.key === key) return glyphCache.canvas;
 
     const baseScale = Math.max(0.1, bevel / 100);
@@ -132,6 +133,12 @@ function getGlyphSprite(char, cell, color, bevel) {
     gCtx.textAlign = 'center';
     gCtx.textBaseline = 'middle';
     gCtx.fillText(char, sz / 2, sz / 2 + (cell * 0.05));
+    if (colorize) {
+        gCtx.globalCompositeOperation = 'source-in';
+        gCtx.fillStyle = color;
+        gCtx.fillRect(0, 0, sz, sz);
+        gCtx.globalCompositeOperation = 'source-over';
+    }
 
     glyphCache.key = key;
     return gc;
@@ -141,7 +148,7 @@ function renderCanvas() {
     if (!currentMatrices) return;
     const { nData, oData, oV } = currentMatrices;
     const shape = E('data-shape')?.value || 'solid';
-    const colorStyle = E('grad-style')?.value || 'linear';
+    const colorStyle = E('grad-style')?.value || 'solid';
     const densityMapStyle = E('density-map-style')?.value || 'uniform';
 
     const dB = parseInt(E('data-bevel')?.value || '75');
@@ -202,7 +209,15 @@ function renderCanvas() {
 
         const bgS = E('color-bg-start')?.value || '#ffffff', bgE = E('color-bg-end')?.value || '#ffffff';
         const fgS = E('color-start')?.value || '#000000', fgE = E('color-end')?.value || '#000000';
-        const gradStyle2 = E('grad-style')?.value || 'linear';
+        const optContainer = E('opt-container');
+        const miniRoot = E('mobile-sticky-root');
+        if (optContainer) optContainer.style.background = bgS;
+        if (miniRoot) miniRoot.style.background = bgS;
+        const fgFrame = E('finder-frame-color')?.value || fgS, fgPupil = E('finder-pupil-color')?.value || fgS;
+        const alignFrame = matchFinders ? fgFrame : (E('align-frame-color')?.value || fgFrame);
+        const alignPupil = matchFinders ? fgPupil : (E('align-pupil-color')?.value || fgPupil);
+        const finderPupilMode = E('finder-pupil-mode')?.value || 'big';
+        const gradStyle2 = E('grad-style')?.value || 'solid';
         const gradAngle2 = E('grad-angle')?.value || '135';
         const gradRadial2 = E('grad-radial')?.value || '100';
         const gradKey = `${bgS}|${bgE}|${fgS}|${fgE}|${gradStyle2}|${gradAngle2}|${gradRadial2}|${cSz}`;
@@ -314,13 +329,25 @@ function renderCanvas() {
             if (heatmap) { ctx.fillRect(x, y, (type==='finder'?7:5)*size, (type==='finder'?7:5)*size); return; }
             const structFB = type === 'finder' ? fB : alignFB;
             const structPB = type === 'finder' ? pB : alignPB;
+            const frameFill = type === 'finder' ? fgFrame : alignFrame;
+            const pupilFill = type === 'finder' ? fgPupil : alignPupil;
             if (type === 'finder') {
                 const s = 7*size, rO = (s/2)*(structFB/100), rG = (5*size/2)*(structFB/100), rI = (3*size/2)*(structPB/100);
+                if (!heatmap && colorStyle !== 'image') ctx.fillStyle = frameFill;
                 ctx.beginPath(); roundRectPath(ctx, x, y, s, s, rO); roundRectPath(ctx, x+size, y+size, 5*size, 5*size, rG); ctx.fill('evenodd');
-                ctx.beginPath(); roundRectPath(ctx, x+2*size, y+2*size, 3*size, 3*size, rI); ctx.fill();
+                if (!heatmap && colorStyle !== 'image') ctx.fillStyle = pupilFill;
+                if (finderPupilMode === 'modules') {
+                    for (let pr = 0; pr < 3; pr++) for (let pc = 0; pc < 3; pc++) {
+                        ctx.beginPath(); roundRectPath(ctx, x+(2+pc)*size, y+(2+pr)*size, size, size, (size/2)*(structPB/100)); ctx.fill();
+                    }
+                } else {
+                    ctx.beginPath(); roundRectPath(ctx, x+2*size, y+2*size, 3*size, 3*size, rI); ctx.fill();
+                }
             } else {
                 const s = 5*size, rO = (s/2)*(structFB/100), rG = (3*size/2)*(structFB/100), rI = (size/2)*(structPB/100);
+                if (!heatmap && colorStyle !== 'image') ctx.fillStyle = frameFill;
                 ctx.beginPath(); roundRectPath(ctx, x, y, s, s, rO); roundRectPath(ctx, x+size, y+size, 3*size, 3*size, rG); ctx.fill('evenodd');
+                if (!heatmap && colorStyle !== 'image') ctx.fillStyle = pupilFill;
                 ctx.beginPath(); roundRectPath(ctx, x+2*size, y+2*size, size, size, rI); ctx.fill();
             }
         };
@@ -335,7 +362,7 @@ function renderCanvas() {
             }); });
         }
 
-        const solidPath = new Path2D();
+        const batchSolidPath = shape === 'solid' && !isAnimated ? new Path2D() : null;
 
         // CHARACTER MODE
         // Rasterize glyph once via getGlyphSprite(), then stamp with drawImage().
@@ -343,7 +370,7 @@ function renderCanvas() {
         if (isCharMode) {
             const char = E('module-char')?.value || '\u2605';
             const fgColor = E('color-start')?.value || '#000000';
-            const sprite = getGlyphSprite(char, cell, fgColor, dB);
+            const sprite = getGlyphSprite(char, cell, fgColor, dB, E('module-char-colorize')?.checked);
             const sprSz = sprite.width;
             const offset = (cell - sprSz) / 2;
 
@@ -431,7 +458,9 @@ function renderCanvas() {
                 }
 
                 if (shape === 'solid') {
-                    roundRectPath(solidPath, cx, cy, cell + 0.5, cell + 0.5, Math.max(0, (cell/2)*(dB/100)));
+                    const solidTarget = batchSolidPath || ctx;
+                    roundRectPath(solidTarget, cx, cy, cell + 0.5, cell + 0.5, Math.max(0, (cell/2)*(dB/100)));
+                    if (!batchSolidPath) ctx.fill();
                 } else if (shape === 'organic') {
                     const rad = Math.max(0, (cell/2)*(dB/100));
                     const t = shouldRenderData(r-1,c), b = shouldRenderData(r+1,c), l = shouldRenderData(r,c-1), ri = shouldRenderData(r,c+1);
@@ -483,9 +512,9 @@ function renderCanvas() {
             }
         }
             // Flush all solid modules in one GPU draw call
-            if (shape === 'solid') {
+            if (batchSolidPath) {
                 ctx.fillStyle = heatmap ? ctx.fillStyle : fgGrad;
-                ctx.fill(solidPath);
+                ctx.fill(batchSolidPath);
             }
         } // end shape branch
 
@@ -595,5 +624,33 @@ function startAnimIfNeeded() {
     }
 }
 
-// Poll scannability independently at 500ms — decoupled from the 60fps render loop
-setInterval(checkScannability, 500);
+// Poll scannability independently from the 60fps render loop. jsQR reads back
+// canvas pixels synchronously, so running it every 500ms while the mesh is
+// animating creates a visible cadence hitch. Static previews keep the fast
+// scan cadence; animated previews scan less often and prefer idle time.
+let scanPollPending = false;
+let lastScanPollTime = 0;
+
+function scheduleScannabilityCheck() {
+    if (scanPollPending || typeof checkScannability !== 'function') return;
+
+    const isAnimatedPreview = E('anim-toggle')?.checked || getHasAnimatedGif();
+    const pollDelay = isAnimatedPreview ? 2500 : 500;
+    const now = performance.now();
+    if (now - lastScanPollTime < pollDelay) return;
+
+    scanPollPending = true;
+    const runScan = () => {
+        scanPollPending = false;
+        lastScanPollTime = performance.now();
+        checkScannability();
+    };
+
+    if ('requestIdleCallback' in window) {
+        requestIdleCallback(runScan, { timeout: isAnimatedPreview ? 2000 : 500 });
+    } else {
+        setTimeout(runScan, isAnimatedPreview ? 250 : 0);
+    }
+}
+
+setInterval(scheduleScannabilityCheck, 250);


### PR DESCRIPTION
### Motivation

- Improve color and gradient UX by supporting a solid fill mode, hiding gradient controls when not applicable, and adding a one‑click `Invert` action.  
- Expose more module/finder customization such as forcing glyph foreground color, per-finder/ alignment colors and finder center rendering modes.  
- Reduce JS work during animated previews by throttling canvas scannability checks and batching static module draws for better performance.

### Description

- Updated UI in `fpqr/index.html` to reorganize the character module controls and add a `module-char-colorize` checkbox, hide gradient end inputs by default, add an `Invert` button (`#invert-colors`), and add finder/alignment color pickers and a `finder-pupil-mode` select.  
- Adjusted gradient options and labels (default `solid` added) and renamed several slider labels for clarity.  
- In `fpqr/js/app.js` added `updateImageMapVisibility()` logic to show/hide gradient end inputs and arrow glyphs depending on `grad-style`, added the `Invert` handler that swaps background/foreground colors, and tweaked event handling for gradient UI.  
- In `fpqr/js/qr-engine.js` scannability logic now detects animated previews and adapts the testing canvas size and scoring heuristics for better results with animated GIFs.  
- In `fpqr/js/renderer.js`: `createEngineGradient()` returns a solid color when `grad-style` is `solid` or `image`; `getGlyphSprite()` gained a `colorize` flag to force glyph foreground color; finder/alignment drawing now supports separate frame/center colors and a `finder-pupil-mode` that can render the center as a single block or 3x3 modules; solid modules are batched into a `Path2D` when the preview is static to reduce GPU draw calls; background of preview containers is kept in sync with chosen background color.  
- Replaced the fixed `setInterval(checkScannability, 500)` with a scheduled poll (`scheduleScannabilityCheck`) that uses `requestIdleCallback` or timed fallbacks and adapts delay for animated previews to reduce jank.

### Testing

- Ran linting with `npm run lint` and code style checks, which completed successfully.  
- Executed unit tests with `npm test`, and the test suite passed.  
- Performed automated headless rendering smoke tests for static and animated previews (canvas render + `jsQR` scannability checks), which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eebdc165c83269f45d21f9a6a1f99)