### PR TITLE
Add collapsible option panels, gradient controls, finder/alignment styling, and scan optimizations

### DIFF
--- a/fpqr/css/styles.css
+++ b/fpqr/css/styles.css
@@ -225,3 +225,21 @@ input[type="color"]::-webkit-color-swatch {
     pointer-events: none; 
     z-index: -999; 
 }
+
+/* Playful option reveals for feature-specific controls. */
+.option-reveal {
+    max-height: 420px;
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    overflow: hidden;
+    transition: max-height 260ms cubic-bezier(0.34, 1.56, 0.64, 1), opacity 180ms ease, transform 260ms cubic-bezier(0.34, 1.56, 0.64, 1), margin 260ms ease, padding 260ms ease;
+}
+.option-reveal.is-collapsed {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-6px) scale(0.98);
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    pointer-events: none;
+}

--- a/fpqr/index.html
+++ b/fpqr/index.html
@@ -117,7 +117,7 @@
                         <select id="data-shape" class="w-full bg-[#0f111a] border border-slate-700 rounded-lg px-3 py-2.5 text-sm font-bold text-white outline-none focus:border-indigo-500 render-trigger cursor-pointer">
                             <option value="solid" selected>Solid Blocks</option>
                             <option value="organic">Organic Blocks</option>
-                            <option value="halftone">Radial Scale / Halftone</option>
+                            <option value="halftone">Halftone (Luminance Dots)</option>
                             <option value="leaf">Leaf / Petal</option>
                             <option value="diamond">Diamonds</option>
                             <option value="dots">Circular Dots</option>
@@ -128,9 +128,18 @@
                         </select>
 
                         <div id="custom-module-container" class="hidden flex flex-col gap-3 bg-[#13151f] px-3 py-3 rounded-lg border border-dashed border-slate-700">
-                            <div id="module-char-container" class="hidden flex items-center justify-between">
-                                <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Character / Emoji</span>
-                                <input type="text" id="module-char" value="&#9733;" maxlength="3" class="bg-[#0f111a] border border-slate-700 outline-none rounded text-sm text-white px-2 py-1 w-16 text-center render-trigger">
+                            <div id="module-char-container" class="hidden flex flex-col gap-3">
+                                <div class="flex items-center justify-between">
+                                    <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Character / Emoji</span>
+                                    <input type="text" id="module-char" value="&#9733;" maxlength="3" class="bg-[#0f111a] border border-slate-700 outline-none rounded text-sm text-white px-2 py-1 w-16 text-center render-trigger">
+                                </div>
+                                <div class="flex items-center justify-between">
+                                    <span class="text-[10px] font-bold text-slate-500 uppercase">Force foreground color</span>
+                                    <label class="relative inline-flex items-center cursor-pointer m-0">
+                                        <input type="checkbox" id="module-char-colorize" class="sr-only peer render-trigger">
+                                        <div class="w-7 h-3.5 shrink-0 bg-slate-700 rounded-full peer peer-checked:bg-indigo-500 after:content-[''] after:absolute after:top-[1px] after:left-[1px] after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:after:translate-x-3.5"></div>
+                                    </label>
+                                </div>
                             </div>
                             <div id="module-image-container" class="hidden flex items-center justify-between">
                                 <span class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Image Source</span>
@@ -151,24 +160,26 @@
                                     <div class="flex items-center gap-1.5">
                                         <span class="text-[10px] font-bold text-slate-500">BG</span>
                                         <input type="color" id="color-bg-start" value="#ffffff" class="render-trigger">
-                                        <span class="text-slate-600 text-xs">&rarr;</span>
-                                        <input type="color" id="color-bg-end" value="#ffffff" class="render-trigger">
+                                        <span data-gradient-arrow class="text-slate-600 text-xs hidden">&rarr;</span>
+                                        <input type="color" id="color-bg-end" value="#ffffff" class="render-trigger hidden">
                                     </div>
                                     <div class="w-px h-5 bg-slate-700"></div>
                                     <div class="flex items-center gap-1.5 transition-opacity" id="fg-color-container">
                                         <span class="text-[10px] font-bold text-slate-500">FG</span>
                                         <input type="color" id="color-start" value="#000000" class="render-trigger">
-                                        <span class="text-slate-600 text-xs">&rarr;</span>
-                                        <input type="color" id="color-end" value="#000000" class="render-trigger">
+                                        <span data-gradient-arrow class="text-slate-600 text-xs hidden">&rarr;</span>
+                                        <input type="color" id="color-end" value="#000000" class="render-trigger hidden">
                                     </div>
                                 </div>
                             </div>
                             <div class="flex items-center gap-3 mt-1">
                                 <select id="grad-style" class="bg-slate-800 border-none outline-none rounded text-[10px] text-white px-2 py-1.5 font-bold uppercase render-trigger cursor-pointer">
-                                    <option value="linear">Linear</option>
-                                    <option value="radial">Radial</option>
-                                    <option value="image">Image Mask</option>
+                                    <option value="solid" selected>Solid</option>
+                                    <option value="linear">Linear Gradient</option>
+                                    <option value="radial">Radial Gradient</option>
+                                    <option value="image">Image Color Map</option>
                                 </select>
+                                <button id="invert-colors" type="button" class="text-[10px] bg-slate-800 hover:bg-slate-700 text-slate-200 px-2 py-1.5 rounded font-bold uppercase tracking-wider">Invert</button>
                                 <div class="flex items-center gap-2 flex-1 transition-opacity" id="grad-control-container">
                                     <div id="grad-angle-wrapper" class="flex items-center gap-2 flex-1 w-full">
                                         <svg class="w-3.5 h-3.5 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>
@@ -289,18 +300,29 @@
                                         <div class="custom-tooltip tooltip-right">Renders the finders using your chosen data aesthetic instead of standard square blocks.</div>
                                     </div>
                                     <label class="relative inline-flex items-center cursor-pointer m-0">
-                                        <input type="checkbox" id="native-finders" class="sr-only peer render-trigger">
+                                        <input type="checkbox" id="native-finders" class="sr-only peer render-trigger" checked>
                                         <div class="w-7 h-3.5 shrink-0 bg-slate-700 rounded-full peer peer-checked:bg-cyan-500 after:content-[''] after:absolute after:top-[1px] after:left-[1px] after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:after:translate-x-3.5"></div>
                                     </label>
                                 </div>
                             </div>
-                            <div>
-                                <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Outer Curves</span><span id="frame-bevel-val" class="text-white font-mono">50%</span></div>
+                            <div class="finder-options option-reveal is-collapsed">
+                                <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Finder Frame Radius</span><span id="frame-bevel-val" class="text-white font-mono">50%</span></div>
                                 <input type="range" id="frame-bevel" min="0" max="100" value="50" class="w-full render-trigger">
                             </div>
-                            <div>
-                                <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Inner Curves</span><span id="pupil-bevel-val" class="text-white font-mono">50%</span></div>
+                            <div class="finder-options option-reveal is-collapsed">
+                                <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Finder Center Radius</span><span id="pupil-bevel-val" class="text-white font-mono">50%</span></div>
                                 <input type="range" id="pupil-bevel" min="0" max="100" value="50" class="w-full render-trigger">
+                            </div>
+                            <div class="finder-options option-reveal is-collapsed grid grid-cols-2 gap-3">
+                                <label class="flex items-center justify-between text-[10px] font-bold text-slate-500 uppercase">Frame <input type="color" id="finder-frame-color" value="#000000" class="render-trigger"></label>
+                                <label class="flex items-center justify-between text-[10px] font-bold text-slate-500 uppercase">Center <input type="color" id="finder-pupil-color" value="#000000" class="render-trigger"></label>
+                            </div>
+                            <div class="finder-options option-reveal is-collapsed flex items-center justify-between border-t border-slate-800 pt-3">
+                                <span class="text-[10px] font-bold text-slate-500 uppercase">Center style</span>
+                                <select id="finder-pupil-mode" class="bg-slate-800 border-none outline-none rounded text-[10px] text-white px-2 py-1.5 font-bold uppercase render-trigger cursor-pointer">
+                                    <option value="big" selected>One block</option>
+                                    <option value="modules">3x3 modules</option>
+                                </select>
                             </div>
                         </div>
 
@@ -333,20 +355,24 @@
                                             <div class="custom-tooltip tooltip-right">Renders alignments using your chosen data aesthetic instead of standard square blocks.</div>
                                         </div>
                                         <label class="relative inline-flex items-center cursor-pointer m-0">
-                                            <input type="checkbox" id="native-alignments" class="sr-only peer render-trigger">
+                                            <input type="checkbox" id="native-alignments" class="sr-only peer render-trigger" checked>
                                             <div class="w-7 h-3.5 shrink-0 bg-slate-700 rounded-full peer peer-checked:bg-indigo-500 after:content-[''] after:absolute after:top-[1px] after:left-[1px] after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:after:translate-x-3.5"></div>
                                         </label>
                                     </div>
                                 </div>
                             </div>
-                            <div id="align-sliders" class="space-y-4 opacity-30 pointer-events-none transition-opacity">
+                            <div id="align-sliders" class="option-reveal is-collapsed space-y-4 opacity-30 pointer-events-none transition-opacity">
                                 <div>
-                                    <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Outer Curves</span><span id="align-frame-bevel-val" class="text-white font-mono">50%</span></div>
+                                    <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Alignment Frame Radius</span><span id="align-frame-bevel-val" class="text-white font-mono">50%</span></div>
                                     <input type="range" id="align-frame-bevel" min="0" max="100" value="50" class="w-full render-trigger">
                                 </div>
                                 <div>
-                                    <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Inner Curves</span><span id="align-pupil-bevel-val" class="text-white font-mono">50%</span></div>
+                                    <div class="flex justify-between text-[10px] mb-1 font-bold"><span class="text-slate-500 uppercase">Alignment Center Radius</span><span id="align-pupil-bevel-val" class="text-white font-mono">50%</span></div>
                                     <input type="range" id="align-pupil-bevel" min="0" max="100" value="50" class="w-full render-trigger">
+                                </div>
+                                <div class="grid grid-cols-2 gap-3">
+                                    <label class="flex items-center justify-between text-[10px] font-bold text-slate-500 uppercase">Frame <input type="color" id="align-frame-color" value="#000000" class="render-trigger"></label>
+                                    <label class="flex items-center justify-between text-[10px] font-bold text-slate-500 uppercase">Center <input type="color" id="align-pupil-color" value="#000000" class="render-trigger"></label>
                                 </div>
                             </div>
                         </div>
@@ -403,10 +429,10 @@
                     <div class="flex justify-start items-center gap-4">
                         <span class="text-xs font-bold text-slate-400 uppercase tracking-widest">Logo Geometry</span>
                         <div class="flex bg-slate-800 rounded-lg p-1 border border-slate-700">
-                            <button id="shape-none" class="shape-btn p-1.5 rounded-md transition-all text-slate-400 hover:text-white" title="No Logo">
+                            <button id="shape-none" class="shape-btn active p-1.5 rounded-md transition-all text-slate-400 hover:text-white" title="No Logo">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
                             </button>
-                            <button id="shape-square" class="shape-btn active p-1.5 rounded-md transition-all text-slate-400 hover:text-white" title="Square Logo">
+                            <button id="shape-square" class="shape-btn p-1.5 rounded-md transition-all text-slate-400 hover:text-white" title="Square Logo">
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><rect x="4" y="4" width="16" height="16" rx="3"/></svg>
                             </button>
                             <button id="shape-circle" class="shape-btn p-1.5 rounded-md transition-all text-slate-400 hover:text-white" title="Circle Logo">
@@ -415,7 +441,7 @@
                         </div>
                     </div>
 
-                    <div class="flex items-center justify-between pt-3 border-t border-slate-800/50">
+                    <div class="logo-options option-reveal is-collapsed flex items-center justify-between pt-3 border-t border-slate-800/50">
                         <span class="text-xs font-bold text-slate-400 uppercase tracking-widest">Custom Image</span>
                         <div class="flex items-center gap-3">
                             <span id="logo-filename" class="text-xs text-slate-500 max-w-[100px] truncate">None</span>
@@ -425,18 +451,18 @@
                         </div>
                     </div>
 
-                    <div class="flex items-center gap-5">
+                    <div class="logo-options option-reveal is-collapsed flex items-center gap-5">
                         <span class="text-xs font-bold text-slate-500 uppercase tracking-widest w-16">Scale</span>
                         <input type="range" id="logo-size" min="5" max="50" value="25" class="flex-1 render-trigger">
                         <span id="logo-size-val" class="text-sm font-mono font-bold text-emerald-400 w-10 text-right">25%</span>
                     </div>
-                    <div class="flex items-center gap-5">
+                    <div class="logo-options option-reveal is-collapsed flex items-center gap-5">
                         <span class="text-xs font-bold text-slate-500 uppercase tracking-widest w-16">Buffer</span>
                         <input type="range" id="logo-padding" min="0" max="15" value="1" class="flex-1 render-trigger">
                         <span id="logo-padding-val" class="text-sm font-mono font-bold text-slate-300 w-10 text-right">1%</span>
                     </div>
                     
-                    <div class="flex items-center justify-between pt-3 border-t border-slate-800">
+                    <div class="logo-options option-reveal is-collapsed flex items-center justify-between pt-3 border-t border-slate-800">
                         <div class="flex items-center gap-2">
                             <span class="text-xs font-bold text-slate-400 uppercase tracking-widest">Omit Obscured Modules</span>
                             <div class="has-tooltip p-2 -m-2 cursor-help">
@@ -510,7 +536,7 @@
                             </label>
                         </div>
 
-                        <div class="bg-white p-3 rounded-2xl shadow-2xl border border-emerald-500/30 relative overflow-hidden flex items-center justify-center w-full max-w-[320px] aspect-square" id="opt-container">
+                        <div class="bg-white p-1 rounded-2xl shadow-2xl border border-emerald-500/30 relative overflow-hidden flex items-center justify-center w-full max-w-[320px] aspect-square" id="opt-container">
                             <canvas id="qr-optimal" style="width: 100%; height: 100%;" class="max-w-full"></canvas>
                             
                             <div id="gif-progress" class="hidden absolute inset-0 bg-[#0f111a]/90 backdrop-blur-sm flex flex-col items-center justify-center z-30">

--- a/fpqr/js/app.js
+++ b/fpqr/js/app.js
@@ -210,9 +210,40 @@ const initApp = () => {
         E('density-map-upload-container')?.classList.toggle('hidden', dms !== 'image');
         E('fg-color-container')?.classList.toggle('opacity-30', gs === 'image');
         E('fg-color-container')?.classList.toggle('pointer-events-none', gs === 'image');
+        const isGradient = gs === 'linear' || gs === 'radial';
+        E('color-bg-end')?.classList.toggle('hidden', !isGradient);
+        E('color-end')?.classList.toggle('hidden', !isGradient);
+        document.querySelectorAll('[data-gradient-arrow]').forEach(el => el.classList.toggle('hidden', !isGradient));
         if (gs === 'image' && !colorMapImage) genDefaultImageMap('color');
         if (dms === 'image' && !densityMapImage) genDefaultImageMap('density');
     }
+
+
+    function setOptionExpanded(el, expanded) {
+        if (!el) return;
+        el.classList.toggle('is-collapsed', !expanded);
+    }
+
+    function updateLogoVisibility() {
+        document.querySelectorAll('.logo-options').forEach(el => setOptionExpanded(el, logoShape !== 'none'));
+    }
+
+    function updateStructuralVisibility() {
+        const findersNative = E('native-finders')?.checked;
+        const alignmentsNative = E('native-alignments')?.checked;
+        const alignMatch = E('match-finders')?.checked;
+        document.querySelectorAll('.finder-options').forEach(el => setOptionExpanded(el, !findersNative));
+        const alignSliders = E('align-sliders');
+        if (alignSliders) {
+            const showAlignOptions = !alignmentsNative;
+            setOptionExpanded(alignSliders, showAlignOptions);
+            alignSliders.classList.toggle('opacity-30', showAlignOptions && !!alignMatch);
+            alignSliders.classList.toggle('pointer-events-none', showAlignOptions && !!alignMatch);
+        }
+    }
+
+    updateStructuralVisibility();
+    updateLogoVisibility();
 
     E('show-naive')?.addEventListener('change', (e) => {
         E('naive-container')?.classList.toggle('hidden', !e.target.checked);
@@ -235,6 +266,7 @@ const initApp = () => {
                 if (settings['logoShape']) {
                     logoShape = settings['logoShape'];
                     ['none', 'square', 'circle'].forEach(s => E(`shape-${s}`)?.classList.toggle('active', s === logoShape));
+                    updateLogoVisibility();
                 }
                 const ds = E('data-shape')?.value;
                 const isChar = ds === 'character';
@@ -243,7 +275,7 @@ const initApp = () => {
                 E('module-char-container')?.classList.toggle('hidden', !isChar);
                 E('module-image-container')?.classList.toggle('hidden', !isImg);
                 const gs = E('grad-style')?.value;
-                E('grad-angle-wrapper')?.classList.toggle('hidden', gs === 'radial' || gs === 'image');
+                E('grad-angle-wrapper')?.classList.toggle('hidden', gs !== 'linear');
                 E('grad-radial-wrapper')?.classList.toggle('hidden', gs !== 'radial');
                 updateImageMapVisibility();
                 if (E('anim-toggle')?.checked) {
@@ -255,6 +287,7 @@ const initApp = () => {
                     E('anim-settings')?.classList.add('hidden');
                     if (!getHasAnimatedGif()) E('export-gif-btn')?.classList.add('hidden');
                 }
+                updateStructuralVisibility();
                 if (E('show-naive')) E('naive-container')?.classList.toggle('hidden', !E('show-naive').checked);
                 if (typeof analyzeData === 'function') analyzeData();
                 showToast('Settings applied successfully!');
@@ -357,6 +390,10 @@ const initApp = () => {
         }
     });
 
+    ['native-finders', 'native-alignments', 'match-finders'].forEach(id => {
+        E(id)?.addEventListener('change', () => { updateStructuralVisibility(); renderCanvas(); });
+    });
+
     E('density-map-style')?.addEventListener('change', () => {
         updateImageMapVisibility();
         renderCanvas();
@@ -366,9 +403,18 @@ const initApp = () => {
         const val = e.target.value;
         const isRadial = val === 'radial';
         const isImage = val === 'image';
-        E('grad-angle-wrapper')?.classList.toggle('hidden', isRadial || isImage);
+        E('grad-angle-wrapper')?.classList.toggle('hidden', val !== 'linear');
         E('grad-radial-wrapper')?.classList.toggle('hidden', !isRadial);
         updateImageMapVisibility();
+        renderCanvas();
+    });
+
+    E('invert-colors')?.addEventListener('click', () => {
+        const bgStart = E('color-bg-start'), bgEnd = E('color-bg-end');
+        const fgStart = E('color-start'), fgEnd = E('color-end');
+        if (!bgStart || !bgEnd || !fgStart || !fgEnd) return;
+        [bgStart.value, fgStart.value] = [fgStart.value, bgStart.value];
+        [bgEnd.value, fgEnd.value] = [fgEnd.value, bgEnd.value];
         renderCanvas();
     });
 
@@ -385,9 +431,9 @@ const initApp = () => {
         }
     });
 
-    if(E('shape-none')) E('shape-none').onclick = () => { logoShape = 'none'; E('shape-none')?.classList.add('active'); E('shape-square')?.classList.remove('active'); E('shape-circle')?.classList.remove('active'); renderCanvas(); };
-    if(E('shape-square')) E('shape-square').onclick = () => { logoShape = 'square'; E('shape-square')?.classList.add('active'); E('shape-none')?.classList.remove('active'); E('shape-circle')?.classList.remove('active'); renderCanvas(); };
-    if(E('shape-circle')) E('shape-circle').onclick = () => { logoShape = 'circle'; E('shape-circle')?.classList.add('active'); E('shape-none')?.classList.remove('active'); E('shape-square')?.classList.remove('active'); renderCanvas(); };
+    if(E('shape-none')) E('shape-none').onclick = () => { logoShape = 'none'; E('shape-none')?.classList.add('active'); E('shape-square')?.classList.remove('active'); E('shape-circle')?.classList.remove('active'); updateLogoVisibility(); renderCanvas(); };
+    if(E('shape-square')) E('shape-square').onclick = () => { logoShape = 'square'; E('shape-square')?.classList.add('active'); E('shape-none')?.classList.remove('active'); E('shape-circle')?.classList.remove('active'); updateLogoVisibility(); renderCanvas(); };
+    if(E('shape-circle')) E('shape-circle').onclick = () => { logoShape = 'circle'; E('shape-circle')?.classList.add('active'); E('shape-none')?.classList.remove('active'); E('shape-square')?.classList.remove('active'); updateLogoVisibility(); renderCanvas(); };
 
     E('isolate-modal')?.addEventListener('click', (e) => {
         if (e.target.id === 'isolate-modal' || e.target.closest('#close-modal')) {

--- a/fpqr/js/qr-engine.js
+++ b/fpqr/js/qr-engine.js
@@ -185,8 +185,9 @@ function checkScannability() {
     if (!optCan || !container) return;
 
     const targetStr = currentMatrices.res.finalString;
+    const isAnimated = E('anim-toggle')?.checked || (typeof getHasAnimatedGif === 'function' && getHasAnimatedGif());
     let score = 0;
-    const s = 512;
+    const s = isAnimated ? 256 : 512;
 
     const drawAndTest = (transformFn, filterStr = 'none') => {
         validateCtx.fillStyle = '#ffffff';
@@ -206,19 +207,20 @@ function checkScannability() {
     };
 
     if (drawAndTest()) {
-        score += 40; 
-        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.8, 0.8); ctx.translate(-s/2, -s/2); })) score += 15;
-        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.6, 0.6); ctx.translate(-s/2, -s/2); })) score += 15;
-        if (drawAndTest(null, 'blur(0.5px)')) score += 15;
-        if (drawAndTest(null, 'blur(1px)')) score += 15;
+        score += isAnimated ? 70 : 40;
+        if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.8, 0.8); ctx.translate(-s/2, -s/2); })) score += isAnimated ? 30 : 15;
+        if (!isAnimated) {
+            if (drawAndTest(ctx => { ctx.translate(s/2, s/2); ctx.scale(0.6, 0.6); ctx.translate(-s/2, -s/2); })) score += 15;
+            if (drawAndTest(null, 'blur(0.5px)')) score += 15;
+            if (drawAndTest(null, 'blur(1px)')) score += 15;
+        }
     } else {
-        if (drawAndTest(null, 'contrast(400%) grayscale(100%)')) { score += 20; } 
-        else if (drawAndTest(null, 'brightness(200%) contrast(400%) grayscale(100%)')) { score += 20; } 
-        else if (drawAndTest(null, 'brightness(50%) contrast(400%) grayscale(100%)')) { score += 20; }
-        else if (drawAndTest(null, 'invert(100%) contrast(400%) grayscale(100%)')) { score += 20; }
+        if (drawAndTest(null, 'contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'brightness(200%) contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'brightness(50%) contrast(400%) grayscale(100%)')) { score += 20; }
+        else if (!isAnimated && drawAndTest(null, 'invert(100%) contrast(400%) grayscale(100%)')) { score += 20; }
     }
 
-    const isAnimated = E('anim-toggle')?.checked || (typeof getHasAnimatedGif === 'function' && getHasAnimatedGif());
 
     const updateBadge = (scoreNum, text, barColorClass, textColorClass) => {
         const bar = E('scan-score-bar');

--- a/fpqr/js/renderer.js
+++ b/fpqr/js/renderer.js
@@ -1,5 +1,5 @@
 // Drawing State Globals
-let logoShape = 'square';
+let logoShape = 'none';
 let globalTime = 0;
 window.isExporting = false;
 
@@ -77,7 +77,8 @@ function getCurrentGifFrame(gifData, timeMs) {
 }
 
 function createEngineGradient(ctx, cSz, c1, c2) {
-    const gradStyle = E('grad-style')?.value || 'linear';
+    const gradStyle = E('grad-style')?.value || 'solid';
+    if (gradStyle === 'solid' || gradStyle === 'image' || c1 === c2) return c1;
     let grad;
     if (gradStyle === 'radial') {
         const rScale = parseInt(E('grad-radial')?.value || '100') / 100;
@@ -115,8 +116,8 @@ function getMapData(activeImage, gSz, ctx, canvas) {
 // Rasterizes the character once onto an offscreen canvas; every module then
 // uses drawImage() instead of fillText(), which is much faster on iOS Safari.
 // Cache key: char + cellSize + color + bevel -- any change triggers a rebuild.
-function getGlyphSprite(char, cell, color, bevel) {
-    const key = char + '|' + Math.round(cell) + '|' + color + '|' + bevel;
+function getGlyphSprite(char, cell, color, bevel, colorize) {
+    const key = char + '|' + Math.round(cell) + '|' + color + '|' + bevel + '|' + colorize;
     if (glyphCache.key === key) return glyphCache.canvas;
 
     const baseScale = Math.max(0.1, bevel / 100);
@@ -132,6 +133,12 @@ function getGlyphSprite(char, cell, color, bevel) {
     gCtx.textAlign = 'center';
     gCtx.textBaseline = 'middle';
     gCtx.fillText(char, sz / 2, sz / 2 + (cell * 0.05));
+    if (colorize) {
+        gCtx.globalCompositeOperation = 'source-in';
+        gCtx.fillStyle = color;
+        gCtx.fillRect(0, 0, sz, sz);
+        gCtx.globalCompositeOperation = 'source-over';
+    }
 
     glyphCache.key = key;
     return gc;
@@ -141,7 +148,7 @@ function renderCanvas() {
     if (!currentMatrices) return;
     const { nData, oData, oV } = currentMatrices;
     const shape = E('data-shape')?.value || 'solid';
-    const colorStyle = E('grad-style')?.value || 'linear';
+    const colorStyle = E('grad-style')?.value || 'solid';
     const densityMapStyle = E('density-map-style')?.value || 'uniform';
 
     const dB = parseInt(E('data-bevel')?.value || '75');
@@ -159,14 +166,6 @@ function renderCanvas() {
     const alignFB = matchFinders ? fB : parseInt(E('align-frame-bevel')?.value || '50');
     const alignPB = matchFinders ? pB : parseInt(E('align-pupil-bevel')?.value || '50');
 
-    if (domCache['matchFinders'] !== matchFinders) {
-        const alignSliders = E('align-sliders');
-        if (alignSliders) {
-            alignSliders.style.opacity = matchFinders ? '0.3' : '1';
-            alignSliders.style.pointerEvents = matchFinders ? 'none' : 'auto';
-        }
-        domCache['matchFinders'] = matchFinders;
-    }
 
     const updates = {
         'frame-bevel-val': fB + '%',
@@ -202,7 +201,15 @@ function renderCanvas() {
 
         const bgS = E('color-bg-start')?.value || '#ffffff', bgE = E('color-bg-end')?.value || '#ffffff';
         const fgS = E('color-start')?.value || '#000000', fgE = E('color-end')?.value || '#000000';
-        const gradStyle2 = E('grad-style')?.value || 'linear';
+        const optContainer = E('opt-container');
+        const miniRoot = E('mobile-sticky-root');
+        if (optContainer) optContainer.style.background = bgS;
+        if (miniRoot) miniRoot.style.background = bgS;
+        const fgFrame = E('finder-frame-color')?.value || fgS, fgPupil = E('finder-pupil-color')?.value || fgS;
+        const alignFrame = matchFinders ? fgFrame : (E('align-frame-color')?.value || fgFrame);
+        const alignPupil = matchFinders ? fgPupil : (E('align-pupil-color')?.value || fgPupil);
+        const finderPupilMode = E('finder-pupil-mode')?.value || 'big';
+        const gradStyle2 = E('grad-style')?.value || 'solid';
         const gradAngle2 = E('grad-angle')?.value || '135';
         const gradRadial2 = E('grad-radial')?.value || '100';
         const gradKey = `${bgS}|${bgE}|${fgS}|${fgE}|${gradStyle2}|${gradAngle2}|${gradRadial2}|${cSz}`;
@@ -314,13 +321,25 @@ function renderCanvas() {
             if (heatmap) { ctx.fillRect(x, y, (type==='finder'?7:5)*size, (type==='finder'?7:5)*size); return; }
             const structFB = type === 'finder' ? fB : alignFB;
             const structPB = type === 'finder' ? pB : alignPB;
+            const frameFill = type === 'finder' ? fgFrame : alignFrame;
+            const pupilFill = type === 'finder' ? fgPupil : alignPupil;
             if (type === 'finder') {
                 const s = 7*size, rO = (s/2)*(structFB/100), rG = (5*size/2)*(structFB/100), rI = (3*size/2)*(structPB/100);
+                if (!heatmap && colorStyle !== 'image') ctx.fillStyle = frameFill;
                 ctx.beginPath(); roundRectPath(ctx, x, y, s, s, rO); roundRectPath(ctx, x+size, y+size, 5*size, 5*size, rG); ctx.fill('evenodd');
-                ctx.beginPath(); roundRectPath(ctx, x+2*size, y+2*size, 3*size, 3*size, rI); ctx.fill();
+                if (!heatmap && colorStyle !== 'image') ctx.fillStyle = pupilFill;
+                if (finderPupilMode === 'modules') {
+                    for (let pr = 0; pr < 3; pr++) for (let pc = 0; pc < 3; pc++) {
+                        ctx.beginPath(); roundRectPath(ctx, x+(2+pc)*size, y+(2+pr)*size, size, size, (size/2)*(structPB/100)); ctx.fill();
+                    }
+                } else {
+                    ctx.beginPath(); roundRectPath(ctx, x+2*size, y+2*size, 3*size, 3*size, rI); ctx.fill();
+                }
             } else {
                 const s = 5*size, rO = (s/2)*(structFB/100), rG = (3*size/2)*(structFB/100), rI = (size/2)*(structPB/100);
+                if (!heatmap && colorStyle !== 'image') ctx.fillStyle = frameFill;
                 ctx.beginPath(); roundRectPath(ctx, x, y, s, s, rO); roundRectPath(ctx, x+size, y+size, 3*size, 3*size, rG); ctx.fill('evenodd');
+                if (!heatmap && colorStyle !== 'image') ctx.fillStyle = pupilFill;
                 ctx.beginPath(); roundRectPath(ctx, x+2*size, y+2*size, size, size, rI); ctx.fill();
             }
         };
@@ -335,7 +354,7 @@ function renderCanvas() {
             }); });
         }
 
-        const solidPath = new Path2D();
+        const batchSolidPath = shape === 'solid' && !isAnimated ? new Path2D() : null;
 
         // CHARACTER MODE
         // Rasterize glyph once via getGlyphSprite(), then stamp with drawImage().
@@ -343,7 +362,7 @@ function renderCanvas() {
         if (isCharMode) {
             const char = E('module-char')?.value || '\u2605';
             const fgColor = E('color-start')?.value || '#000000';
-            const sprite = getGlyphSprite(char, cell, fgColor, dB);
+            const sprite = getGlyphSprite(char, cell, fgColor, dB, E('module-char-colorize')?.checked);
             const sprSz = sprite.width;
             const offset = (cell - sprSz) / 2;
 
@@ -408,6 +427,10 @@ function renderCanvas() {
                     let imgLuma = (hMapDensity[idx]*0.299 + hMapDensity[idx+1]*0.587 + hMapDensity[idx+2]*0.114);
                     if (E('invert-density-map')?.checked) imgLuma = 255 - imgLuma;
                     sizeFactor = imgLuma / 255;
+                } else if (shape === 'halftone' && colorStyle === 'image' && hMapColor) {
+                    const idx = (r * gSz + c) * 4;
+                    const imgLuma = (hMapColor[idx]*0.299 + hMapColor[idx+1]*0.587 + hMapColor[idx+2]*0.114);
+                    sizeFactor = Math.max(0.12, 1 - (imgLuma / 255));
                 }
 
                 let dX = 0, dY = 0, dS = sizeFactor;
@@ -431,7 +454,9 @@ function renderCanvas() {
                 }
 
                 if (shape === 'solid') {
-                    roundRectPath(solidPath, cx, cy, cell + 0.5, cell + 0.5, Math.max(0, (cell/2)*(dB/100)));
+                    const solidTarget = batchSolidPath || ctx;
+                    roundRectPath(solidTarget, cx, cy, cell + 0.5, cell + 0.5, Math.max(0, (cell/2)*(dB/100)));
+                    if (!batchSolidPath) ctx.fill();
                 } else if (shape === 'organic') {
                     const rad = Math.max(0, (cell/2)*(dB/100));
                     const t = shouldRenderData(r-1,c), b = shouldRenderData(r+1,c), l = shouldRenderData(r,c-1), ri = shouldRenderData(r,c+1);
@@ -483,9 +508,9 @@ function renderCanvas() {
             }
         }
             // Flush all solid modules in one GPU draw call
-            if (shape === 'solid') {
+            if (batchSolidPath) {
                 ctx.fillStyle = heatmap ? ctx.fillStyle : fgGrad;
-                ctx.fill(solidPath);
+                ctx.fill(batchSolidPath);
             }
         } // end shape branch
 
@@ -595,5 +620,33 @@ function startAnimIfNeeded() {
     }
 }
 
-// Poll scannability independently at 500ms — decoupled from the 60fps render loop
-setInterval(checkScannability, 500);
+// Poll scannability independently from the 60fps render loop. jsQR reads back
+// canvas pixels synchronously, so running it every 500ms while the mesh is
+// animating creates a visible cadence hitch. Static previews keep the fast
+// scan cadence; animated previews scan less often and prefer idle time.
+let scanPollPending = false;
+let lastScanPollTime = 0;
+
+function scheduleScannabilityCheck() {
+    if (scanPollPending || typeof checkScannability !== 'function') return;
+
+    const isAnimatedPreview = E('anim-toggle')?.checked || getHasAnimatedGif();
+    const pollDelay = isAnimatedPreview ? 2500 : 500;
+    const now = performance.now();
+    if (now - lastScanPollTime < pollDelay) return;
+
+    scanPollPending = true;
+    const runScan = () => {
+        scanPollPending = false;
+        lastScanPollTime = performance.now();
+        checkScannability();
+    };
+
+    if ('requestIdleCallback' in window) {
+        requestIdleCallback(runScan, { timeout: isAnimatedPreview ? 2000 : 500 });
+    } else {
+        setTimeout(runScan, isAnimatedPreview ? 250 : 0);
+    }
+}
+
+setInterval(scheduleScannabilityCheck, 250);


### PR DESCRIPTION
### Motivation

- Make advanced UI controls less noisy by collapsing feature-specific option groups and exposing them only when relevant.  
- Improve color/gradient UX with a solid/default mode, visible gradient controls when applicable, and a quick invert action.  
- Provide more flexible finder/alignment styling (colors, radii, pupil modes) and sensible defaults for logos.  
- Reduce scanning cadence impact during animated previews and improve scannability checks for animated vs static previews.

### Description

- Added a new reveal/collapse animation style in `fpqr/css/styles.css` (`.option-reveal` / `.is-collapsed`) and applied it to multiple option groups in `fpqr/index.html` to hide advanced controls by default.  
- Updated UI controls in `fpqr/index.html`: renamed gradient options to include `Solid`, `Linear Gradient`, `Radial Gradient`, `Image Color Map`, hid gradient end inputs by default, added an `Invert` button, and reworked module/character controls to include a `Force foreground color` checkbox and compact layout.  
- Enhanced structural/finder and alignment controls: defaulted `native-finders` and `native-alignments` to checked, added color pickers and a `finder-pupil-mode` in HTML, and set logo default to `none` (renderer default changed in `fpqr/js/renderer.js`).  
- Implemented visibility and UI state helpers in `fpqr/js/app.js` (`updateImageMapVisibility`, `setOptionExpanded`, `updateLogoVisibility`, `updateStructuralVisibility`), hooked change listeners for the new controls, added gradient-end showing/hiding logic, and wired the `Invert` button to swap foreground/background color pairs.  
- Adjusted rendering engine in `fpqr/js/renderer.js`: changed default gradient style to `solid`, updated `createEngineGradient` early-return for solid/image cases, added finder/alignment color usage, added `finderPupilMode` support (single block vs 3x3 modules), added batch path optimization for `solid` mode (`batchSolidPath`) to reduce draw calls, supported halftone sizing when using an image color map, and changed initial `logoShape` to `'none'`.  
- Modified glyph rasterization (`getGlyphSprite`) to accept a `colorize` flag and included handling to colorize glyph sprites.  
- Improved scannability logic in `fpqr/js/qr-engine.js` by adapting test canvas size and scoring for animated previews and making some scoring branches skip for animated mode.  
- Reworked periodic scannability polling in `fpqr/js/renderer.js`: replaced the fixed 500ms `setInterval(checkScannability, 500)` with an adaptive scheduler (`scheduleScannabilityCheck`) that polls less frequently for animated previews and uses `requestIdleCallback` when available to avoid jank; polling runs via `setInterval(scheduleScannabilityCheck, 250)`.  

### Testing

- Ran project linting with `npm run lint` which completed without errors.  
- Built the project with `npm run build` and verified the production bundle was produced successfully.  
- Performed an automated smoke render by starting the dev build and verifying UI scripts initialized (headless unit tests are not present); initialization hooks (`initApp`, event listeners) executed and no runtime exceptions were observed in the build logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eebdc165c83269f45d21f9a6a1f99)