### PR TITLE
Add 3D print scanimation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ A collection of web-based tools and interactive viewers.
 - **[Wine Tool](https://e-z-g.github.io/wine.html)** — Wine reference/utility tool.
 - **[VR Video](https://e-z-g.github.io/vrvid.html)** — VR video player.
 - **[Star/Planet Viewer](https://e-z-g.github.io/ev/)** — Generative space scene with star field and planet image, with PNG export.
+- **[3D Print Scanimation Generator](https://e-z-g.github.io/scanimation.html)** — Interlace up to six frames into a printable base plate and sliding barrier grid, with SVG and multi-colour 3MF export.
 - **[FPQR](https://e-z-g.github.io/fpqr/)** — First-person QR experience.

--- a/index.html
+++ b/index.html
@@ -74,6 +74,10 @@
       <span class="desc">Generative space scene with star field and planet image, with PNG export.</span>
     </li>
     <li>
+      <a href="https://e-z-g.github.io/scanimation.html">3D Print Scanimation Generator</a>
+      <span class="desc">Interlace up to six frames into a printable base plate and sliding barrier grid, with SVG and multi-colour 3MF export.</span>
+    </li>
+    <li>
       <a href="https://e-z-g.github.io/fpqr/">FPQR</a>
       <span class="desc">First-person QR experience.</span>
     </li>

--- a/scanimation.html
+++ b/scanimation.html
@@ -1,0 +1,1173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Print Scanimation Generator</title>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Self-contained GIF parser — no CDN dependency -->
+  <script>
+  // Minimal GIF87a/89a decoder.
+  // Exposes window.parseGIFFrames(arrayBuffer) => [{ url, width, height, delay }]
+  (function() {
+    function parseGIFFrames(buffer) {
+      const data = new Uint8Array(buffer);
+      let pos = 0;
+      function read(n) { const s = data.slice(pos, pos + n); pos += n; return s; }
+      function readByte() { return data[pos++]; }
+      function readWord() { const v = data[pos] | (data[pos+1] << 8); pos += 2; return v; }
+
+      const header = String.fromCharCode.apply(null, read(6));
+      if (!header.startsWith('GIF')) throw new Error('not a GIF file');
+
+      const width  = readWord();
+      const height = readWord();
+      const packed = readByte();
+      readByte(); // background colour index
+      readByte(); // pixel aspect ratio
+
+      const hasGCT = (packed >> 7) & 1;
+      const gctSize = 2 << (packed & 7);
+      const gct = hasGCT ? read(gctSize * 3) : null;
+
+      const frames = [];
+      let gcExt = null;
+
+      const canvas = document.createElement('canvas');
+      canvas.width = width; canvas.height = height;
+      const canvasCtx = canvas.getContext('2d', { willReadFrequently: true });
+
+      // Backup canvas for disposal method 3 (restore to previous).
+      const backup = document.createElement('canvas');
+      backup.width = width; backup.height = height;
+      const backupCtx = backup.getContext('2d');
+
+      function decodeLZW(minCode, bytes) {
+        const clearCode = 1 << minCode;
+        const eoiCode = clearCode + 1;
+        let codeSize = minCode + 1;
+        let dict = [];
+        function initDict() {
+          dict = [];
+          for (let i = 0; i < clearCode; i++) dict.push([i]);
+          dict.push([clearCode]); dict.push([eoiCode]);
+          codeSize = minCode + 1;
+        }
+        initDict();
+
+        const out = [];
+        let p = 0, bits = 0, buf = 0, prev = null;
+
+        function readCode() {
+          while (bits < codeSize) {
+            if (p >= bytes.length) return -1;
+            buf |= bytes[p++] << bits;
+            bits += 8;
+          }
+          const code = buf & ((1 << codeSize) - 1);
+          buf >>= codeSize; bits -= codeSize;
+          return code;
+        }
+
+        let code;
+        while ((code = readCode()) !== -1) {
+          if (code === clearCode) { initDict(); prev = null; continue; }
+          if (code === eoiCode) break;
+          let entry;
+          if (code < dict.length) entry = dict[code];
+          else if (code === dict.length && prev !== null) entry = prev.concat(prev[0]);
+          else break;
+          for (let i = 0; i < entry.length; i++) out.push(entry[i]);
+          if (prev !== null) {
+            dict.push(prev.concat(entry[0]));
+            if (dict.length === (1 << codeSize) && codeSize < 12) codeSize++;
+          }
+          prev = entry;
+        }
+        return out;
+      }
+
+      function readSubBlocks() {
+        const out = [];
+        let size;
+        while ((size = readByte()) !== 0) {
+          for (let i = 0; i < size; i++) out.push(readByte());
+        }
+        return new Uint8Array(out);
+      }
+
+      while (pos < data.length) {
+        const sentinel = readByte();
+        if (sentinel === 0x3B) break; // trailer
+
+        if (sentinel === 0x21) { // extension
+          const label = readByte();
+          if (label === 0xF9) { // graphic control
+            readByte(); // block size (always 4)
+            const epacked = readByte();
+            const delay = readWord();
+            const transIdx = readByte();
+            readByte(); // terminator
+            gcExt = {
+              disposal: (epacked >> 3) & 7,
+              transparent: (epacked & 1) ? transIdx : -1,
+              delay
+            };
+          } else {
+            readSubBlocks(); // skip comment/application/plain-text
+          }
+          continue;
+        }
+
+        if (sentinel === 0x2C) { // image descriptor
+          const left = readWord();
+          const top  = readWord();
+          const fw   = readWord();
+          const fh   = readWord();
+          const ipacked = readByte();
+          const hasLCT = (ipacked >> 7) & 1;
+          const interlaced = (ipacked >> 6) & 1;
+          const lctSize = 2 << (ipacked & 7);
+          const ct = hasLCT ? read(lctSize * 3) : gct;
+
+          const minCode = readByte();
+          const indices = decodeLZW(minCode, readSubBlocks());
+
+          const disposal = gcExt ? gcExt.disposal : 0;
+          if (disposal === 3) {
+            backupCtx.clearRect(0, 0, width, height);
+            backupCtx.drawImage(canvas, 0, 0);
+          }
+
+          const frameCanvas = document.createElement('canvas');
+          frameCanvas.width = fw; frameCanvas.height = fh;
+          const fCtx = frameCanvas.getContext('2d');
+          const imgData = fCtx.createImageData(fw, fh);
+          const px = imgData.data;
+          const transIdx = gcExt ? gcExt.transparent : -1;
+
+          // Row r of the output comes from row srcRows[r] of the decoded stream.
+          const srcRows = new Array(fh);
+          if (interlaced) {
+            const passes = [
+              { start: 0, step: 8 }, { start: 4, step: 8 },
+              { start: 2, step: 4 }, { start: 1, step: 2 }
+            ];
+            let srcRow = 0;
+            for (const { start, step } of passes) {
+              for (let r = start; r < fh; r += step) srcRows[r] = srcRow++;
+            }
+          } else {
+            for (let r = 0; r < fh; r++) srcRows[r] = r;
+          }
+
+          for (let r = 0; r < fh; r++) {
+            const srcRow = srcRows[r];
+            for (let c = 0; c < fw; c++) {
+              const idx = indices[srcRow * fw + c];
+              const d4 = (r * fw + c) * 4;
+              if (idx === undefined || idx === transIdx) {
+                px[d4 + 3] = 0;
+              } else if (ct) {
+                px[d4]     = ct[idx * 3];
+                px[d4 + 1] = ct[idx * 3 + 1];
+                px[d4 + 2] = ct[idx * 3 + 2];
+                px[d4 + 3] = 255;
+              }
+            }
+          }
+          fCtx.putImageData(imgData, 0, 0);
+          canvasCtx.drawImage(frameCanvas, left, top);
+
+          const snap = document.createElement('canvas');
+          snap.width = width; snap.height = height;
+          snap.getContext('2d').drawImage(canvas, 0, 0);
+          frames.push({ canvas: snap, delay: gcExt ? Math.max(gcExt.delay * 10, 20) : 100 });
+
+          // Apply this frame's disposal before the next one is composited.
+          if (disposal === 2) {
+            canvasCtx.clearRect(left, top, fw, fh);
+          } else if (disposal === 3) {
+            canvasCtx.clearRect(0, 0, width, height);
+            canvasCtx.drawImage(backup, 0, 0);
+          }
+          gcExt = null;
+          continue;
+        }
+
+        // Unknown block — bail out rather than spin.
+        break;
+      }
+
+      if (frames.length === 0) throw new Error('no frames found');
+
+      return frames.map(f => ({
+        url: f.canvas.toDataURL('image/png'),
+        width, height, delay: f.delay
+      }));
+    }
+
+    window.parseGIFFrames = parseGIFFrames;
+  })();
+  </script>
+
+  <!-- Self-contained ZIP writer (STORE only) — no CDN dependency -->
+  <script>
+  // 3MF is a ZIP container. Deflate buys little on already-small XML, so we
+  // store entries uncompressed and skip the JSZip download entirely.
+  // Exposes window.makeZipBlob([{ name, text }]) => Blob
+  (function() {
+    const CRC_TABLE = (() => {
+      const t = new Uint32Array(256);
+      for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+        t[n] = c >>> 0;
+      }
+      return t;
+    })();
+
+    function crc32(bytes) {
+      let c = 0xFFFFFFFF;
+      for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xFF] ^ (c >>> 8);
+      return (c ^ 0xFFFFFFFF) >>> 0;
+    }
+
+    function makeZipBlob(entries) {
+      const enc = new TextEncoder();
+      const files = entries.map(e => ({
+        nameBytes: enc.encode(e.name),
+        data: enc.encode(e.text)
+      }));
+
+      const chunks = [];
+      const central = [];
+      let offset = 0;
+
+      const u16 = (v) => [v & 0xFF, (v >>> 8) & 0xFF];
+      const u32 = (v) => [v & 0xFF, (v >>> 8) & 0xFF, (v >>> 16) & 0xFF, (v >>> 24) & 0xFF];
+
+      for (const f of files) {
+        const crc = crc32(f.data);
+        // Bit 11 flags UTF-8 filenames. Fixed DOS timestamp keeps output
+        // byte-identical across runs.
+        const header = [].concat(
+          u32(0x04034B50), u16(20), u16(0x0800), u16(0),
+          u16(0), u16(0x21), // 1980-01-01
+          u32(crc), u32(f.data.length), u32(f.data.length),
+          u16(f.nameBytes.length), u16(0)
+        );
+        chunks.push(new Uint8Array(header), f.nameBytes, f.data);
+
+        central.push(new Uint8Array([].concat(
+          u32(0x02014B50), u16(20), u16(20), u16(0x0800), u16(0),
+          u16(0), u16(0x21),
+          u32(crc), u32(f.data.length), u32(f.data.length),
+          u16(f.nameBytes.length), u16(0), u16(0),
+          u16(0), u16(0), u32(0),
+          u32(offset)
+        )), f.nameBytes);
+
+        offset += header.length + f.nameBytes.length + f.data.length;
+      }
+
+      const centralStart = offset;
+      let centralSize = 0;
+      for (const c of central) centralSize += c.length;
+
+      const end = new Uint8Array([].concat(
+        u32(0x06054B50), u16(0), u16(0),
+        u16(files.length), u16(files.length),
+        u32(centralSize), u32(centralStart), u16(0)
+      ));
+
+      return new Blob(chunks.concat(central, [end]), { type: 'application/vnd.ms-package.3dmanufacturing-3dmodel+xml' });
+    }
+
+    window.makeZipBlob = makeZipBlob;
+  })();
+  </script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+const { useState, useEffect, useRef, useCallback, useMemo } = React;
+
+const CANVAS_SIZE = 500;      // working resolution in px; all px values map to mm via `sf`
+const BORDER_PX = 10;         // grid frame thickness, in working px
+const HANDLE_W_PX = 25;
+const HANDLE_H_PX = 40;
+const MAX_FRAMES = 6;
+const MIN_FRAMES = 2;
+const GRID_COLOR = '#1a1a1a';
+const PLATE_GAP_MM = 20;      // spacing between base and grid on the build plate
+
+/* ---------------------------------------------------------------- colour */
+
+const hexToRgb = (hex) => {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return m
+    ? { r: parseInt(m[1], 16), g: parseInt(m[2], 16), b: parseInt(m[3], 16) }
+    : { r: 0, g: 0, b: 0 };
+};
+
+// Rec. 601 luma — matches how the eye weights channels, so thresholding a
+// colour image gives a silhouette that looks like the original.
+const luma = (r, g, b) => 0.299 * r + 0.587 * g + 0.114 * b;
+
+// Nearest palette entry by squared RGB distance. The palette is pre-parsed by
+// the caller: this runs once per pixel, so hex parsing here is far too slow.
+const nearestIndex = (r, g, b, rgbPalette) => {
+  let best = 0, bestDist = Infinity;
+  for (let i = 0; i < rgbPalette.length; i++) {
+    const p = rgbPalette[i];
+    const dr = r - p.r, dg = g - p.g, db = b - p.b;
+    const d = dr * dr + dg * dg + db * db;
+    if (d < bestDist) { bestDist = d; best = i; }
+  }
+  return best;
+};
+
+/* -------------------------------------------------------------- geometry */
+
+// Otsu's method: pick the threshold that maximises between-class variance of
+// the luma histogram. Beats guessing at a slider for photographic sources.
+const otsuThreshold = (canvas) => {
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  const d = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+  const hist = new Array(256).fill(0);
+  for (let i = 0; i < d.length; i += 4) hist[Math.round(luma(d[i], d[i+1], d[i+2]))]++;
+
+  const total = d.length / 4;
+  let sum = 0;
+  for (let i = 0; i < 256; i++) sum += i * hist[i];
+
+  let sumB = 0, wB = 0, best = 128, bestVar = -1;
+  for (let t = 0; t < 256; t++) {
+    wB += hist[t];
+    if (wB === 0) continue;
+    const wF = total - wB;
+    if (wF === 0) break;
+    sumB += t * hist[t];
+    const mB = sumB / wB;
+    const mF = (sum - sumB) / wF;
+    const between = wB * wF * (mB - mF) * (mB - mF);
+    if (between > bestVar) { bestVar = between; best = t; }
+  }
+  return best;
+};
+
+// One extruded box, in mm, with explicit Z range so parts can stack on a plate.
+const box = (x, y, w, h, z0, z1) => ({ x, y, w, h, z0, z1 });
+
+/* ------------------------------------------------------------------ 3MF */
+
+// Vertex order per box: 0-3 are the z0 face (CCW seen from below), 4-7 the z1
+// face. Y is flipped on the way in so the model is not mirrored relative to
+// the SVG, whose Y axis points down.
+const CUBE_FACES = [
+  [0, 3, 2], [0, 2, 1], // bottom  (-Z)
+  [4, 5, 6], [4, 6, 7], // top     (+Z)
+  [0, 1, 5], [0, 5, 4], // front   (-Y)
+  [1, 2, 6], [1, 6, 5], // right   (+X)
+  [2, 3, 7], [2, 7, 6], // back    (+Y)
+  [3, 0, 4], [3, 4, 7]  // left    (-X)
+];
+
+const meshXml = (boxes, flipHeight) => {
+  const v = [];
+  const t = [];
+  boxes.forEach((b, i) => {
+    const x0 = b.x, x1 = b.x + b.w;
+    // SVG y grows downward; 3MF y grows upward.
+    const y0 = flipHeight - (b.y + b.h), y1 = flipHeight - b.y;
+    const z0 = b.z0, z1 = b.z1;
+    const corners = [
+      [x0, y0, z0], [x1, y0, z0], [x1, y1, z0], [x0, y1, z0],
+      [x0, y0, z1], [x1, y0, z1], [x1, y1, z1], [x0, y1, z1]
+    ];
+    for (const [x, y, z] of corners) {
+      v.push(`<vertex x="${x.toFixed(4)}" y="${y.toFixed(4)}" z="${z.toFixed(4)}"/>`);
+    }
+    const o = i * 8;
+    for (const [a, b2, c] of CUBE_FACES) {
+      t.push(`<triangle v1="${o + a}" v2="${o + b2}" v3="${o + c}"/>`);
+    }
+  });
+  return `      <mesh>
+        <vertices>
+          ${v.join('\n          ')}
+        </vertices>
+        <triangles>
+          ${t.join('\n          ')}
+        </triangles>
+      </mesh>`;
+};
+
+const xmlEscape = (s) => String(s).replace(/[<>&"]/g, (c) =>
+  ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' }[c]));
+
+// parts: [{ name, offsetX, flipHeight, groups: [{ color, boxes }] }]
+const build3MF = (parts) => {
+  const colors = [];
+  for (const part of parts) {
+    for (const g of part.groups) {
+      if (g.boxes.length && !colors.includes(g.color)) colors.push(g.color);
+    }
+  }
+
+  let resources = `    <m:colorgroup id="1">\n`;
+  for (const c of colors) {
+    resources += `      <m:color color="${c.toUpperCase()}FF"/>\n`;
+  }
+  resources += `    </m:colorgroup>\n`;
+
+  const items = [];
+  let nextId = 2;
+
+  for (const part of parts) {
+    for (const g of part.groups) {
+      if (!g.boxes.length) continue;
+      const id = nextId++;
+      resources += `    <object id="${id}" type="model" name="${xmlEscape(part.name + ' — ' + g.color)}" pid="1" pindex="${colors.indexOf(g.color)}">\n`;
+      resources += meshXml(g.boxes, part.flipHeight) + '\n';
+      resources += `    </object>\n`;
+      items.push(`    <item objectid="${id}" transform="1 0 0 0 1 0 0 0 1 ${part.offsetX.toFixed(4)} 0 0"/>`);
+    }
+  }
+
+  const model = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02">
+  <metadata name="Application">e-z-g scanimation generator</metadata>
+  <resources>
+${resources}  </resources>
+  <build>
+${items.join('\n')}
+  </build>
+</model>`;
+
+  return window.makeZipBlob([
+    { name: '[Content_Types].xml', text: `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/>
+</Types>` },
+    { name: '_rels/.rels', text: `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Target="/3D/3dmodel.model" Id="rel-1" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel"/>
+</Relationships>` },
+    { name: '3D/3dmodel.model', text: model }
+  ]);
+};
+
+/* -------------------------------------------------------------- download */
+
+const saveBlob = (blob, filename) => {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // Some browsers abort the download if the object URL dies too early.
+  setTimeout(() => URL.revokeObjectURL(url), 10000);
+};
+
+/* ----------------------------------------------------------- demo frames */
+
+const demoFrame = (index, total) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = CANVAS_SIZE;
+  canvas.height = CANVAS_SIZE;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '';
+
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+
+  const progress = total > 1 ? index / (total - 1) : 0;
+  const x = 100 + progress * 300;
+  const y = 380 - Math.sin(progress * Math.PI) * 240;
+
+  ctx.fillStyle = '#000000';
+  ctx.beginPath();
+  ctx.arc(x, y, 70, 0, Math.PI * 2);
+  ctx.fill();
+  return canvas.toDataURL();
+};
+
+const DEFAULT_COLORS = ['#e11d48', '#2563eb', '#16a34a', '#ca8a04', '#7c3aed', '#0891b2'];
+
+const makeDemoFrames = () => [0, 1, 2, 3].map((i) => ({
+  id: i + 1,
+  image: demoFrame(i, 4),
+  threshold: 128,
+  color: DEFAULT_COLORS[i],
+  invert: false
+}));
+
+/* -------------------------------------------------------------- helpers */
+
+const loadImage = (src) => new Promise((resolve) => {
+  const img = new Image();
+  img.crossOrigin = 'anonymous';
+  img.onload = () => resolve(img);
+  img.onerror = () => resolve(null);
+  img.src = src;
+});
+
+// Draw an image into a CANVAS_SIZE square on white, either cropped to fill or
+// letterboxed to fit.
+const rasterize = (img, fit) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = CANVAS_SIZE;
+  canvas.height = CANVAS_SIZE;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+  if (img) {
+    const scale = fit === 'contain'
+      ? Math.min(CANVAS_SIZE / img.width, CANVAS_SIZE / img.height)
+      : Math.max(CANVAS_SIZE / img.width, CANVAS_SIZE / img.height);
+    const dw = img.width * scale, dh = img.height * scale;
+    ctx.drawImage(img, (CANVAS_SIZE - dw) / 2, (CANVAS_SIZE - dh) / 2, dw, dh);
+  }
+  return canvas;
+};
+
+const Slider = ({ label, value, unit, min, max, step, onChange, hint }) => (
+  <div>
+    <div className="flex justify-between text-sm mb-1">
+      <label className="text-neutral-300">{label}</label>
+      <span className="text-indigo-300 font-mono">{value}{unit ? ` ${unit}` : ''}</span>
+    </div>
+    <input type="range" min={min} max={max} step={step} value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+      className="w-full accent-indigo-500" />
+    {hint && <p className="text-xs text-neutral-500 mt-1">{hint}</p>}
+  </div>
+);
+
+const Panel = ({ title, right, children }) => (
+  <div className="bg-neutral-800/50 p-5 rounded-xl border border-neutral-800">
+    <div className="flex items-center justify-between mb-4">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      {right}
+    </div>
+    {children}
+  </div>
+);
+
+/* ------------------------------------------------------------------ app */
+
+function App() {
+  const [stripWidth, setStripWidth] = useState(4);
+  const [physicalSize, setPhysicalSize] = useState(150);
+  const [plateThickness, setPlateThickness] = useState(0.8);
+  const [inkThickness, setInkThickness] = useState(0.8);
+  const [gridThickness, setGridThickness] = useState(1.6);
+  const [colorMode, setColorMode] = useState('silhouette');
+  const [fitMode, setFitMode] = useState('cover');
+  const [palette, setPalette] = useState(['#e11d48', '#2563eb', '#16a34a', '#ca8a04', '#111111', '#ffffff']);
+  const [addHandle, setAddHandle] = useState(true);
+  const [addPlate, setAddPlate] = useState(true);
+  const [plateColor, setPlateColor] = useState('#ffffff');
+
+  const [frames, setFrames] = useState(makeDemoFrames);
+
+  const [playing, setPlaying] = useState(false);
+  const [playMode, setPlayMode] = useState('pingpong');
+  const [speed, setSpeed] = useState(2.5);
+  const [progress, setProgress] = useState(0);
+
+  const [basePng, setBasePng] = useState('');
+  const [gridPng, setGridPng] = useState('');
+  const [baseSvg, setBaseSvg] = useState('');
+  const [gridSvg, setGridSvg] = useState('');
+  const [baseGroups, setBaseGroups] = useState([]);
+  const [gridGroups, setGridGroups] = useState([]);
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const [status, setStatus] = useState('');
+
+  const fileInputRef = useRef(null);
+  const gifInputRef = useRef(null);
+  const targetFrameRef = useRef(null);
+  // Decoded+rasterized frames, keyed by data URL, so moving a slider does not
+  // re-decode every image.
+  const rasterCache = useRef(new Map());
+
+  const numFrames = frames.length;
+  const period = stripWidth * numFrames;
+  const sf = physicalSize / CANVAS_SIZE;                 // px -> mm
+  const gridWpx = CANVAS_SIZE + period + 2 * BORDER_PX;  // grid overhangs by one period + frame
+  const gridHpx = CANVAS_SIZE + 2 * BORDER_PX;
+  const slitMm = stripWidth * sf;
+
+  const rgbPalette = useMemo(() => palette.map(hexToRgb), [palette]);
+
+  const getRaster = useCallback(async (frame) => {
+    const key = (frame.image || '') + '|' + fitMode;
+    const cached = rasterCache.current.get(key);
+    if (cached) return cached;
+    const img = frame.image ? await loadImage(frame.image) : null;
+    const canvas = rasterize(img, fitMode);
+    // Cache is bounded — a long editing session should not pin every upload.
+    if (rasterCache.current.size > 24) rasterCache.current.clear();
+    rasterCache.current.set(key, canvas);
+    return canvas;
+  }, [fitMode]);
+
+  /* ------------------------------------------------------- generation */
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      if (numFrames === 0) return;
+      setBusy(true);
+      try {
+        const rasters = [];
+        for (const frame of frames) rasters.push(await getRaster(frame));
+        if (cancelled) return;
+
+        const w = CANVAS_SIZE, h = CANVAS_SIZE;
+        const preview = document.createElement('canvas');
+        preview.width = w; preview.height = h;
+        const pCtx = preview.getContext('2d');
+        pCtx.fillStyle = '#ffffff';
+        pCtx.fillRect(0, 0, w, h);
+
+        const svgParts = [];
+        const groups = new Map();
+        const pushBox = (color, b) => {
+          if (!groups.has(color)) groups.set(color, []);
+          groups.get(color).push(b);
+        };
+
+        const zInk0 = addPlate ? plateThickness : 0;
+        const zInk1 = zInk0 + inkThickness;
+
+        if (addPlate) {
+          pushBox(plateColor, box(0, 0, physicalSize, physicalSize, 0, plateThickness));
+          svgParts.push(`<rect width="${physicalSize}" height="${physicalSize}" fill="${plateColor}"/>`);
+        }
+
+        // Column-major scan: each vertical strip samples one frame, and runs of
+        // identical colour collapse into a single box.
+        const columnData = rasters.map((c) => c.getContext('2d', { willReadFrequently: true }));
+
+        for (let x = 0; x < w; x += stripWidth) {
+          const sw = Math.min(stripWidth, w - x);
+          const frameIdx = Math.floor(x / stripWidth) % numFrames;
+          const frame = frames[frameIdx];
+          const data = columnData[frameIdx].getImageData(x, 0, sw, h).data;
+          const centerX = Math.floor(sw / 2);
+
+          let runStart = -1;
+          let runColor = null;
+
+          const flush = (endY) => {
+            if (runColor === null || runStart < 0) return;
+            const rx = x * sf, ry = runStart * sf;
+            const rw = sw * sf, rh = (endY - runStart) * sf;
+            svgParts.push(`<rect x="${rx.toFixed(3)}" y="${ry.toFixed(3)}" width="${rw.toFixed(3)}" height="${rh.toFixed(3)}" fill="${runColor}"/>`);
+            pushBox(runColor, box(rx, ry, rw, rh, zInk0, zInk1));
+            pCtx.fillStyle = runColor;
+            pCtx.fillRect(x, runStart, sw, endY - runStart);
+          };
+
+          for (let y = 0; y < h; y++) {
+            const idx = (y * sw + centerX) * 4;
+            const r = data[idx], g = data[idx + 1], b = data[idx + 2];
+            const dark = luma(r, g, b) < frame.threshold;
+            const solid = frame.invert ? !dark : dark;
+
+            const color = solid
+              ? (colorMode === 'silhouette' ? frame.color : palette[nearestIndex(r, g, b, rgbPalette)])
+              : null;
+
+            if (color !== runColor) {
+              flush(y);
+              runColor = color;
+              runStart = color !== null ? y : -1;
+            }
+          }
+          flush(h);
+        }
+
+        const baseGroupList = Array.from(groups, ([color, boxes]) => ({ color, boxes }));
+
+        setBasePng(preview.toDataURL());
+        setBaseSvg(`<svg xmlns="http://www.w3.org/2000/svg" width="${physicalSize}mm" height="${physicalSize}mm" viewBox="0 0 ${physicalSize} ${physicalSize}">
+<rect width="${physicalSize}" height="${physicalSize}" fill="#ffffff"/>
+${svgParts.join('\n')}
+</svg>`);
+        setBaseGroups(baseGroupList);
+
+        /* ------------------------------------------------------ grid */
+
+        const gridWmm = gridWpx * sf;
+        const gridHmm = gridHpx * sf;
+        const borderMm = BORDER_PX * sf;
+        const periodMm = period * sf;
+        const barMm = stripWidth * (numFrames - 1) * sf;
+        const handleWmm = HANDLE_W_PX * sf;
+        const handleHmm = HANDLE_H_PX * sf;
+        const totalWmm = gridWmm + (addHandle ? handleWmm : 0);
+
+        const gridBoxes = [];
+        const gridSvgParts = [];
+        const addGrid = (x, y, bw, bh) => {
+          if (bw <= 0 || bh <= 0) return;
+          gridBoxes.push(box(x, y, bw, bh, 0, gridThickness));
+          gridSvgParts.push(`<rect x="${x.toFixed(3)}" y="${y.toFixed(3)}" width="${bw.toFixed(3)}" height="${bh.toFixed(3)}" fill="${GRID_COLOR}"/>`);
+        };
+
+        const innerH = gridHmm - 2 * borderMm;
+        addGrid(0, 0, gridWmm, borderMm);                              // top rail
+        addGrid(0, gridHmm - borderMm, gridWmm, borderMm);             // bottom rail
+        addGrid(0, borderMm, borderMm, innerH);                        // left rail
+        addGrid(gridWmm - borderMm, borderMm, borderMm, innerH);       // right rail
+
+        // Barrier bars. Interior x = 0 is aligned with base x = 0, so the slit
+        // of period k covers base columns [k*period, k*period + stripWidth).
+        const innerRight = gridWmm - borderMm;
+        for (let k = 0; ; k++) {
+          const x = borderMm + (k * periodMm) + (stripWidth * sf);
+          if (x >= innerRight) break;
+          addGrid(x, borderMm, Math.min(barMm, innerRight - x), innerH);
+        }
+
+        if (addHandle) {
+          addGrid(gridWmm, (gridHmm - handleHmm) / 2, handleWmm, handleHmm);
+        }
+
+        // Preview overlay: the exact exported grid, drawn with transparent slits.
+        const gCanvas = document.createElement('canvas');
+        gCanvas.width = gridWpx; gCanvas.height = gridHpx;
+        const gCtx = gCanvas.getContext('2d');
+        gCtx.fillStyle = GRID_COLOR;
+        for (const b of gridBoxes) {
+          if (b.x >= gridWmm) continue; // handle sits outside the preview area
+          gCtx.fillRect(b.x / sf, b.y / sf, b.w / sf, b.h / sf);
+        }
+
+        if (cancelled) return;
+        setGridPng(gCanvas.toDataURL());
+        setGridGroups([{ color: GRID_COLOR, boxes: gridBoxes }]);
+        setGridSvg(`<svg xmlns="http://www.w3.org/2000/svg" width="${totalWmm.toFixed(3)}mm" height="${gridHmm.toFixed(3)}mm" viewBox="0 0 ${totalWmm.toFixed(3)} ${gridHmm.toFixed(3)}">
+${gridSvgParts.join('\n')}
+</svg>`);
+        setError(null);
+      } catch (err) {
+        if (!cancelled) setError('Could not generate the model: ' + err.message);
+      } finally {
+        if (!cancelled) setBusy(false);
+      }
+    };
+
+    // Debounced so dragging a slider does not queue a full rebuild per pixel.
+    const timer = setTimeout(run, 120);
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, [frames, stripWidth, physicalSize, colorMode, palette, rgbPalette, addHandle,
+      addPlate, plateColor, plateThickness, inkThickness, gridThickness, fitMode,
+      numFrames, period, sf, gridWpx, gridHpx, getRaster]);
+
+  /* -------------------------------------------------------- animation */
+
+  useEffect(() => {
+    if (!playing) return;
+    let reqId;
+    let start;
+    const durationMs = speed * 1000;
+
+    const tick = (ts) => {
+      if (start === undefined) start = ts;
+      const t = ((ts - start) % durationMs) / durationMs;
+      setProgress(playMode === 'pingpong' ? (t < 0.5 ? t * 2 : 2 - t * 2) : t);
+      reqId = requestAnimationFrame(tick);
+    };
+    reqId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(reqId);
+  }, [playing, playMode, speed]);
+
+  /* ---------------------------------------------------------- exports */
+
+  const exportSvg = (content, name) =>
+    saveBlob(new Blob([content], { type: 'image/svg+xml' }), name);
+
+  const exportCombined = () => {
+    try {
+      const blob = build3MF([
+        { name: 'Base', offsetX: 0, flipHeight: physicalSize, groups: baseGroups },
+        { name: 'Grid', offsetX: physicalSize + PLATE_GAP_MM, flipHeight: gridHpx * sf, groups: gridGroups }
+      ]);
+      saveBlob(blob, 'scanimation_combined.3mf');
+    } catch (err) {
+      setError('3MF export failed: ' + err.message);
+    }
+  };
+
+  const exportPart = (which) => {
+    try {
+      const part = which === 'base'
+        ? { name: 'Base', offsetX: 0, flipHeight: physicalSize, groups: baseGroups }
+        : { name: 'Grid', offsetX: 0, flipHeight: gridHpx * sf, groups: gridGroups };
+      saveBlob(build3MF([part]), `scanimation_${which}.3mf`);
+    } catch (err) {
+      setError('3MF export failed: ' + err.message);
+    }
+  };
+
+  /* --------------------------------------------------------- handlers */
+
+  const updateFrame = (id, patch) =>
+    setFrames((prev) => prev.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+
+  const handleImageUpload = (e) => {
+    const file = e.target.files[0];
+    const id = targetFrameRef.current;
+    if (file && id !== null) {
+      const reader = new FileReader();
+      reader.onload = (ev) => updateFrame(id, { image: ev.target.result });
+      reader.onerror = () => setError('Could not read that image file.');
+      reader.readAsDataURL(file);
+    }
+    e.target.value = '';
+  };
+
+  const handleGifUpload = async (e) => {
+    const file = e.target.files[0];
+    e.target.value = '';
+    if (!file) return;
+
+    setStatus('Decoding GIF…');
+    setError(null);
+    try {
+      const parsed = window.parseGIFFrames(await file.arrayBuffer());
+      // Evenly sample the GIF down to the current frame count, so the loop
+      // stays in phase with the barrier period.
+      const count = Math.min(Math.max(numFrames, MIN_FRAMES), MAX_FRAMES);
+      const sampled = Array.from({ length: count }, (_, i) =>
+        parsed[Math.min(parsed.length - 1, Math.round(i * parsed.length / count))].url);
+
+      rasterCache.current.clear();
+      setFrames(sampled.map((url, i) => ({
+        id: i + 1,
+        image: url,
+        threshold: 128,
+        color: DEFAULT_COLORS[i % DEFAULT_COLORS.length],
+        invert: false
+      })));
+      setStatus(`Loaded ${count} of ${parsed.length} GIF frames.`);
+      setTimeout(() => setStatus(''), 4000);
+    } catch (err) {
+      setError('Could not read that GIF: ' + err.message);
+      setStatus('');
+    }
+  };
+
+  const autoThreshold = async (frame) => {
+    const canvas = await getRaster(frame);
+    updateFrame(frame.id, { threshold: otsuThreshold(canvas) });
+  };
+
+  const addFrame = () => setFrames((prev) => prev.length >= MAX_FRAMES ? prev : [...prev, {
+    id: Math.max(0, ...prev.map((f) => f.id)) + 1,
+    image: null,
+    threshold: 128,
+    color: DEFAULT_COLORS[prev.length % DEFAULT_COLORS.length],
+    invert: false
+  }]);
+
+  const removeFrame = (id) =>
+    setFrames((prev) => prev.length <= MIN_FRAMES ? prev : prev.filter((f) => f.id !== id));
+
+  const thinSlit = slitMm < 0.8;
+
+  /* -------------------------------------------------------------- ui */
+
+  return (
+    <div className="min-h-screen bg-neutral-900 text-neutral-100 p-4 md:p-8 font-sans">
+      <div className="max-w-6xl mx-auto space-y-6">
+
+        <header className="flex flex-col xl:flex-row xl:items-center justify-between pb-6 border-b border-neutral-800 gap-4">
+          <div>
+            <h1 className="text-3xl font-bold bg-gradient-to-r from-indigo-400 to-emerald-400 bg-clip-text text-transparent">
+              3D Print Scanimation Generator
+            </h1>
+            <p className="text-neutral-400 mt-1">
+              Interlace up to six frames into a printable plate and sliding barrier grid.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3 items-center">
+            <div className="flex gap-2 p-1.5 bg-neutral-800 rounded-xl">
+              <button onClick={() => exportSvg(baseSvg, 'scanimation_base.svg')}
+                className="px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 rounded-lg text-sm font-medium">Base SVG</button>
+              <button onClick={() => exportSvg(gridSvg, 'scanimation_grid.svg')}
+                className="px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 rounded-lg text-sm font-medium">Grid SVG</button>
+              <button onClick={() => exportPart('base')}
+                className="px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 rounded-lg text-sm font-medium">Base 3MF</button>
+              <button onClick={() => exportPart('grid')}
+                className="px-3 py-1.5 bg-neutral-700 hover:bg-neutral-600 rounded-lg text-sm font-medium">Grid 3MF</button>
+            </div>
+
+            <div className="p-1.5 bg-indigo-950 border border-indigo-500/30 rounded-xl">
+              <button onClick={exportCombined} disabled={busy || !baseGroups.length}
+                className="px-5 py-1.5 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 rounded-lg text-sm font-bold text-white">
+                {busy ? 'Building…' : 'Download Combined 3MF'}
+              </button>
+            </div>
+          </div>
+        </header>
+
+        {error && (
+          <div className="bg-red-900/40 border border-red-700 text-red-200 px-4 py-3 rounded-lg text-sm">{error}</div>
+        )}
+        {status && !error && (
+          <div className="bg-emerald-900/30 border border-emerald-800 text-emerald-200 px-4 py-3 rounded-lg text-sm">{status}</div>
+        )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
+
+          {/* ------------------------------------------------ controls */}
+          <div className="lg:col-span-5 space-y-6">
+
+            <Panel title="Geometry" right={
+              <button onClick={() => gifInputRef.current.click()}
+                className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">Load GIF</button>
+            }>
+              <div className="space-y-5">
+                <Slider label="Print size (X/Y)" value={physicalSize} unit="mm" min={50} max={250} step={5}
+                  onChange={setPhysicalSize} />
+                <Slider label="Strip width" value={stripWidth} unit="px" min={2} max={10} step={1}
+                  onChange={setStripWidth}
+                  hint={`Slit is ${slitMm.toFixed(2)} mm wide; the opaque bar is ${(slitMm * (numFrames - 1)).toFixed(2)} mm.` +
+                        (thinSlit ? ' ⚠ Below 0.8 mm this is hard to print cleanly — raise the print size or the strip width.' : '')} />
+                <Slider label="Grid thickness" value={gridThickness} unit="mm" min={0.8} max={4} step={0.2}
+                  onChange={setGridThickness} hint="The sliding barrier needs enough stiffness not to bow." />
+                <Slider label="Image thickness" value={inkThickness} unit="mm" min={0.2} max={3} step={0.2}
+                  onChange={setInkThickness} />
+
+                <div className="pt-3 border-t border-neutral-700 space-y-3">
+                  <label className="flex items-center gap-2 text-sm text-neutral-300 cursor-pointer">
+                    <input type="checkbox" checked={addPlate} onChange={(e) => setAddPlate(e.target.checked)}
+                      className="rounded bg-neutral-700 border-neutral-600 text-indigo-500" />
+                    Solid backing plate
+                    {addPlate && (
+                      <input type="color" value={plateColor} onChange={(e) => setPlateColor(e.target.value)}
+                        className="w-6 h-6 rounded border-0 p-0 bg-transparent cursor-pointer" />
+                    )}
+                  </label>
+                  {addPlate && (
+                    <Slider label="Plate thickness" value={plateThickness} unit="mm" min={0.4} max={3} step={0.2}
+                      onChange={setPlateThickness} />
+                  )}
+                  <label className="flex items-center gap-2 text-sm text-neutral-300 cursor-pointer">
+                    <input type="checkbox" checked={addHandle} onChange={(e) => setAddHandle(e.target.checked)}
+                      className="rounded bg-neutral-700 border-neutral-600 text-indigo-500" />
+                    Pull handle on the grid
+                  </label>
+                </div>
+
+                <div className="pt-3 border-t border-neutral-700">
+                  <span className="text-sm text-neutral-300 block mb-2">Image fit</span>
+                  <div className="flex gap-2 p-1 bg-neutral-900 rounded-lg">
+                    {[['cover', 'Crop to fill'], ['contain', 'Fit whole image']].map(([mode, label]) => (
+                      <button key={mode} onClick={() => setFitMode(mode)}
+                        className={`flex-1 py-1.5 text-sm rounded-md ${fitMode === mode ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-white'}`}>
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </Panel>
+
+            <Panel title="Colour mode">
+              <div className="flex gap-2 p-1 bg-neutral-900 rounded-lg mb-4">
+                {[['silhouette', 'Silhouette'], ['original', 'Mapped full colour']].map(([mode, label]) => (
+                  <button key={mode} onClick={() => setColorMode(mode)}
+                    className={`flex-1 py-1.5 text-sm font-medium rounded-md ${colorMode === mode ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-white'}`}>
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              {colorMode === 'original' && (
+                <div className="space-y-2">
+                  <div className="flex justify-between items-center mb-1">
+                    <span className="text-sm text-neutral-400">Filament palette</span>
+                    {palette.length < 8 && (
+                      <button onClick={() => setPalette((p) => [...p, '#cccccc'])}
+                        className="text-xs text-indigo-400 hover:text-indigo-300">+ Add colour</button>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {palette.map((hex, i) => (
+                      <div key={i} className="relative group">
+                        <input type="color" value={hex}
+                          onChange={(e) => setPalette((p) => p.map((c, j) => (j === i ? e.target.value : c)))}
+                          className="w-8 h-8 rounded cursor-pointer border-0 p-0 bg-transparent" />
+                        {palette.length > 2 && (
+                          <button onClick={() => setPalette((p) => p.filter((_, j) => j !== i))}
+                            className="absolute -top-2 -right-2 w-4 h-4 leading-none bg-red-500 text-white text-xs rounded-full opacity-0 group-hover:opacity-100">×</button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                  <p className="text-xs text-neutral-500 mt-2">
+                    Each pixel snaps to the nearest colour here, so the export never needs more filaments than your AMS holds.
+                  </p>
+                </div>
+              )}
+            </Panel>
+
+            <div>
+              <div className="flex justify-between items-center mb-4">
+                <h2 className="text-lg font-semibold">Frames ({numFrames})</h2>
+                {numFrames < MAX_FRAMES && (
+                  <button onClick={addFrame}
+                    className="text-sm bg-neutral-800 hover:bg-neutral-700 px-3 py-1.5 rounded border border-neutral-700">+ Add frame</button>
+                )}
+              </div>
+
+              <div className="space-y-3">
+                {frames.map((frame, index) => (
+                  <div key={frame.id} className="flex gap-4 p-4 bg-neutral-800/40 rounded-xl border border-neutral-800/80 items-center">
+                    <button
+                      onClick={() => { targetFrameRef.current = frame.id; fileInputRef.current.click(); }}
+                      title="Replace this frame's image"
+                      className="w-16 h-16 bg-white border border-neutral-700 rounded overflow-hidden flex-shrink-0 relative group flex items-center justify-center">
+                      {frame.image
+                        ? <img src={frame.image} alt={`Frame ${index + 1}`} className="w-full h-full object-contain" />
+                        : <span className="text-neutral-400 text-xs">empty</span>}
+                      <span className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 flex items-center justify-center text-white text-xs transition-opacity">Upload</span>
+                    </button>
+
+                    <div className="flex-1 space-y-3">
+                      <div className="flex justify-between items-center">
+                        <span className="text-sm font-medium text-neutral-300">Frame {index + 1}</span>
+                        <div className="flex items-center gap-2">
+                          <button onClick={() => autoThreshold(frame)}
+                            className="text-xs text-indigo-400 hover:text-indigo-300">auto</button>
+                          {colorMode === 'silhouette' && (
+                            <input type="color" value={frame.color}
+                              onChange={(e) => updateFrame(frame.id, { color: e.target.value })}
+                              className="w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent" />
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-3">
+                        <span className="text-xs text-neutral-500 w-16 font-mono">{frame.threshold}</span>
+                        <input type="range" min="0" max="255" value={frame.threshold}
+                          onChange={(e) => updateFrame(frame.id, { threshold: Number(e.target.value) })}
+                          className="flex-1 accent-neutral-500 h-1" />
+                        <label className="flex items-center gap-1.5 text-xs text-neutral-400 cursor-pointer">
+                          <input type="checkbox" checked={frame.invert}
+                            onChange={(e) => updateFrame(frame.id, { invert: e.target.checked })}
+                            className="rounded border-neutral-600 bg-neutral-700 text-indigo-500" />
+                          Invert
+                        </label>
+                      </div>
+                    </div>
+
+                    {numFrames > MIN_FRAMES && (
+                      <button onClick={() => removeFrame(frame.id)}
+                        className="p-2 text-neutral-500 hover:text-red-400">✕</button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* ------------------------------------------------- preview */}
+          <div className="lg:col-span-7 space-y-6">
+            <div className="bg-neutral-800/30 p-2 rounded-2xl border border-neutral-800">
+              <div className="relative bg-white rounded-xl overflow-hidden aspect-square w-full max-w-[500px] mx-auto">
+                {basePng && <img src={basePng} alt="Interlaced base" className="absolute inset-0 w-full h-full" />}
+                {gridPng && (
+                  <img src={gridPng} alt="Barrier grid" className="absolute pointer-events-none max-w-none"
+                    style={{
+                      width: `${(gridWpx / CANVAS_SIZE) * 100}%`,
+                      height: `${(gridHpx / CANVAS_SIZE) * 100}%`,
+                      left: `${-((BORDER_PX + progress * period) / CANVAS_SIZE) * 100}%`,
+                      top: `${-(BORDER_PX / CANVAS_SIZE) * 100}%`
+                    }} />
+                )}
+              </div>
+
+              <div className="flex flex-wrap justify-center items-center gap-3 mt-4 mb-2">
+                <button onClick={() => setPlaying((p) => !p)}
+                  className={`px-6 py-2.5 rounded-full font-medium ${playing ? 'bg-neutral-700 text-neutral-200' : 'bg-indigo-600 text-white'}`}>
+                  {playing ? 'Pause' : 'Preview animation'}
+                </button>
+                <div className="flex gap-1 p-1 bg-neutral-900 rounded-lg text-sm">
+                  {[['pingpong', 'Ping-pong'], ['loop', 'Loop']].map(([mode, label]) => (
+                    <button key={mode} onClick={() => setPlayMode(mode)}
+                      className={`px-3 py-1 rounded-md ${playMode === mode ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-white'}`}>
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="max-w-sm mx-auto px-4 pb-2 space-y-3">
+                <Slider label="Sweep duration" value={speed} unit="s" min={0.5} max={6} step={0.5} onChange={setSpeed} />
+                {!playing && (
+                  <Slider label="Grid position" value={Number(progress.toFixed(2))} unit="" min={0} max={1} step={0.01}
+                    onChange={setProgress} hint="Drag to step through the frames by hand." />
+                )}
+              </div>
+            </div>
+
+            <div className="bg-neutral-800/30 border border-neutral-800 p-5 rounded-xl text-sm">
+              <h3 className="text-base font-semibold mb-3">Export summary</h3>
+              <dl className="grid grid-cols-2 gap-y-1.5 text-neutral-300">
+                <dt className="text-neutral-500">Base</dt>
+                <dd className="font-mono">{physicalSize} × {physicalSize} × {(( addPlate ? plateThickness : 0) + inkThickness).toFixed(1)} mm</dd>
+                <dt className="text-neutral-500">Grid</dt>
+                <dd className="font-mono">{((gridWpx + (addHandle ? HANDLE_W_PX : 0)) * sf).toFixed(1)} × {(gridHpx * sf).toFixed(1)} × {gridThickness.toFixed(1)} mm</dd>
+                <dt className="text-neutral-500">Slit / bar</dt>
+                <dd className="font-mono">{slitMm.toFixed(2)} / {(slitMm * (numFrames - 1)).toFixed(2)} mm</dd>
+                <dt className="text-neutral-500">Travel</dt>
+                <dd className="font-mono">{(period * sf).toFixed(1)} mm for a full cycle</dd>
+                <dt className="text-neutral-500">Filaments</dt>
+                <dd className="font-mono">{baseGroups.length} on the base, 1 on the grid</dd>
+              </dl>
+            </div>
+
+            <div className="bg-emerald-950/30 border border-emerald-900/50 p-5 rounded-xl">
+              <h3 className="text-lg font-semibold text-emerald-400 mb-3">Print workflow</h3>
+              <ol className="list-decimal list-inside text-sm text-neutral-300 space-y-2">
+                <li>Download the combined 3MF and open it in Bambu Studio, PrusaSlicer or OrcaSlicer.</li>
+                <li>The base and grid arrive side by side on the plate, {PLATE_GAP_MM} mm apart.</li>
+                <li>Assign an opaque filament to the whole grid — light leaking through ruins the effect.</li>
+                <li>The base is split into one part per colour; assign your AMS filaments to the matching parts.</li>
+                <li>Print both flat, then slide the grid across the base to animate.</li>
+              </ol>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <input type="file" ref={fileInputRef} onChange={handleImageUpload} accept="image/*" className="hidden" />
+      <input type="file" ref={gifInputRef} onChange={handleGifUpload} accept="image/gif,.gif" className="hidden" />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Turns the standalone React component into a self-contained page in the
style of the other tools here, and fixes several correctness problems in
the geometry and export paths.

Export correctness:
- Every 3MF triangle was wound so its normal pointed into the solid, so
  slicers saw inverted, non-printable meshes. Faces are now wound CCW
  seen from outside; the exported objects are closed, manifold and have
  positive volume.
- Models were mirrored vertically against the SVG, because SVG Y grows
  downward and 3MF Y grows upward. Y is now flipped on export.
- The grid overhung the base by one period but its frame rails sat on top
  of the artwork at both ends of the stroke, and the top and bottom rails
  covered the image. The grid is now inset by its border on all sides, so
  the rails clear the base through the whole sweep.
- Barrier bars could run past the right rail; their width is now clamped.
- The last strip is clamped when the canvas is not a whole number of
  strips wide, instead of sampling out of bounds.

No runtime CDN dependencies: JSZip and gifuct-js were imported from
esm.sh at click time. Replaced with an inline store-only ZIP writer and
the repo's own GIF decoder, extended to handle disposal method 3
(restore to previous) and interlaced frames correctly.

Printability:
- Optional solid backing plate, so image regions are not printed as
  disconnected islands.
- Separate plate, image and grid thicknesses.
- Slit and bar widths reported in mm, with a warning under 0.8 mm, plus
  an export summary of part sizes, travel per cycle and filament count.

Image pipeline:
- Rasterized frames are cached and regeneration is debounced, so dragging
  a slider no longer re-decodes every image per frame of input.
- The palette is pre-parsed to RGB instead of re-parsing hex per pixel.
- Threshold uses Rec. 601 luma rather than a flat channel average, and
  each frame has an Otsu auto-threshold button.
- Cover or contain fit for source images.

Interface:
- The preview overlay is the exported grid itself rather than a CSS
  gradient approximation, so what is previewed is what is exported.
  Verified that at rest the slits expose exactly frame one's columns.
- Scrub the grid by hand, pick ping-pong or loop, set sweep duration.
- GIF import samples to the current frame count instead of always four.
- Errors surface in the page instead of alert() or a swallowed console
  message.
- Frame handlers use functional state updates, fixing stale-closure
  edits, and the demo frames are built once instead of on every render.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KerAqn1VUMrtLrwrATRM4A