### PR TITLE
Fix broken links, load deadlock and audio bleed in cubemap tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A collection of web-based tools and interactive viewers.
 
 ## Tools
 
-- **[Cubemap VR Viewer](https://e-z-g.github.io/cubemap_viewer/)** — Interactive 360° parallax cubemap viewer with depth-driven square transitions, gyroscope support, and custom LDI upload.
+- **[Cubemap VR Viewer](https://e-z-g.github.io/cube/)** — Interactive 360° parallax cubemap viewer with depth-driven square transitions, gyroscope support, and custom LDI upload.
+- **[Cubemap Face Stitcher](https://e-z-g.github.io/cube/stitcher.html)** — Assemble six cube faces into the atlas the viewer's custom LDI mode loads, with per-face rotation and flip.
 - **[QR Code Generator](https://e-z-g.github.io/qr.html)** — Generate and download QR codes in the browser.
 - **[Wine Tool](https://e-z-g.github.io/wine.html)** — Wine reference/utility tool.
 - **[VR Video](https://e-z-g.github.io/vrvid.html)** — VR video player.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ A collection of web-based tools and interactive viewers.
 - **[Star/Planet Viewer](https://e-z-g.github.io/ev/)** — Generative space scene with star field and planet image, with PNG export.
 - **[3D Print Scanimation Generator](https://e-z-g.github.io/scanimation.html)** — Interlace up to six frames into a printable base plate and sliding barrier grid, with SVG and multi-colour 3MF export.
 - **[FPQR](https://e-z-g.github.io/fpqr/)** — First-person QR experience.
+
+## Local preview
+
+Everything here is static, but the two cubemap pages load their assets relatively
+and share an ES module (`cube/atlas-layout.js`), so they need to be served rather
+than opened from disk:
+
+```
+python3 -m http.server 8000
+```
+
+Then open <http://localhost:8000/cube/>.
+
+`cube/atlas-layout.js` is the single definition of the atlas format the stitcher
+writes and the viewer reads. Both layouts (5×3 and the compact 3×2) are described
+there; changing one side without the other will misalign the pole faces.

--- a/cube/atlas-layout.js
+++ b/cube/atlas-layout.js
@@ -1,0 +1,240 @@
+// ============================================================================
+// Cubemap atlas layout — the contract between stitcher.html and index.html.
+//
+// Both pages import this module. Nothing else defines the layout, because the
+// two sides have to agree exactly: the stitcher writes cells at particular
+// rotations and the viewer's sampleAtlas() reads them back on that assumption.
+// Change one without the other and the poles smear, silently.
+//
+// ---------------------------------------------------------------------------
+// Face indices
+//
+// The viewer's cube is a BoxGeometry scaled by (-1, 1, 1), so its six material
+// slots — which are also the `uFace` uniform — cover these directions:
+//
+//   0: -X    1: +X    2: +Y    3: -Y    4: +Z    5: -Z
+//
+// gnomonicUV() in the viewer maps a direction to that face's [0,1] UV. The
+// inverse (faceUvToDir) and the forward projection (dirToFaceUv) live here so
+// the stitcher can resample across face boundaries when building gutters.
+//
+// ---------------------------------------------------------------------------
+// A naming caveat, worth knowing before you trust either label set
+//
+// The viewer's *separate-image* path (getCubemapUrls) hands its six URLs to the
+// material slots in the order [left, right, top, bottom, back, front], i.e. it
+// considers slot 4 to be "back" and slot 5 "front". The *atlas* path assigns
+// slot 4 to the cell this module calls "front" and slot 5 to "back" — the
+// opposite, and likewise for left/right.
+//
+// The two paths never meet, so each is self-consistent, but a set of six files
+// stitched into an atlas comes out rotated 180 degrees in yaw compared with the
+// same files loaded through the separate-image path. That is a different
+// starting heading, not a mirrored or broken cube. The atlas convention below
+// is the one both this module and sampleAtlas() follow; it is left as-is so
+// existing atlases keep working.
+// ============================================================================
+
+export const FACES = ['left', 'front', 'right', 'back', 'top', 'bottom'];
+
+export const FACE_LABELS = {
+  left:  'Left (−X)',  front: 'Front (+Z)',
+  right: 'Right (+X)', back:  'Back (−Z)',
+  top:   'Top (+Y)',   bottom:'Bottom (−Y)'
+};
+
+// Face name -> viewer material index, for the atlas paths.
+export const FACE_INDEX = { right: 0, left: 1, top: 2, bottom: 3, front: 4, back: 5 };
+export const INDEX_FACE = Object.fromEntries(Object.entries(FACE_INDEX).map(([k, v]) => [v, k]));
+
+// ---------------------------------------------------------------------------
+// Layouts
+// ---------------------------------------------------------------------------
+//
+// 5x3 — the original. 15 cells for 6 faces: the top face appears five times and
+// the bottom face five times, each rotated so that its cell's neighbour in the
+// atlas is the wall it is genuinely adjacent to. That redundancy is what buys
+// correct bilinear filtering at the pole edges; sampleAtlas() blends the four
+// rotated copies by quadrant, and because each copy is rotated back by
+// rotateUV() they agree everywhere except at those edges.
+//
+// 3x2 — compact. 6 cells for 6 faces, so 60% fewer pixels at the same face
+// resolution, one texture fetch per fragment instead of up to four at the
+// poles, and a higher usable face size under the browser's canvas area cap.
+// It replaces the duplication with a baked gutter: each cell reserves a border
+// of GUTTER_PX pixels filled by resampling the neighbouring faces, and the
+// viewer insets its UVs by the same fraction. Same effect, a fraction of the
+// pixels.
+
+export const GUTTER_PX = 8;
+
+export const LAYOUTS = {
+  '5x3': {
+    id: '5x3', cols: 5, rows: 3, aspect: 5 / 3, gutter: 0,
+    label: '5×3 (pole-duplicated)',
+    note: 'Original format. Larger, but needs no gutter.',
+    // Cell order is row-major from the top-left of the image.
+    cells: [
+      { face: 'top',    rot: -90, note: 'Top\n-90°' },
+      { face: 'top',    rot:   0, note: 'Top\n0°'   },
+      { face: 'top',    rot:  90, note: 'Top\n+90°' },
+      { face: 'top',    rot: 180, note: 'Top\n180°' },
+      { face: 'top',    rot: -90, note: 'Top\ndup'  },
+      { face: 'left',   rot:   0, note: 'Left'  },
+      { face: 'front',  rot:   0, note: 'Front' },
+      { face: 'right',  rot:   0, note: 'Right' },
+      { face: 'back',   rot:   0, note: 'Back'  },
+      { face: 'left',   rot:   0, note: 'L dup' },
+      { face: 'bottom', rot:  90, note: 'Bot\n+90°' },
+      { face: 'bottom', rot:   0, note: 'Bot\n0°'   },
+      { face: 'bottom', rot: -90, note: 'Bot\n-90°' },
+      { face: 'bottom', rot: 180, note: 'Bot\n180°' },
+      { face: 'bottom', rot:  90, note: 'Bot\ndup'  },
+    ],
+  },
+  '3x2': {
+    id: '3x2', cols: 3, rows: 2, aspect: 3 / 2, gutter: GUTTER_PX,
+    label: '3×2 (compact)',
+    note: 'No duplication; edges filled by a resampled gutter.',
+    cells: [
+      { face: 'left',  rot: 0, note: 'Left'  },
+      { face: 'front', rot: 0, note: 'Front' },
+      { face: 'right', rot: 0, note: 'Right' },
+      { face: 'back',  rot: 0, note: 'Back'   },
+      { face: 'top',   rot: 0, note: 'Top'    },
+      { face: 'bottom',rot: 0, note: 'Bottom' },
+    ],
+  },
+};
+
+// Which cell index holds a given face, for layouts without duplication.
+export function cellIndexOfFace(layout, face) {
+  return layout.cells.findIndex(c => c.face === face);
+}
+
+// Pick a layout from an image's dimensions. 5:3 is 1.667, 3:2 is 1.5.
+export function detectLayout(width, height) {
+  const aspect = width / height;
+  let best = null, bestErr = Infinity;
+  for (const l of Object.values(LAYOUTS)) {
+    const err = Math.abs(aspect - l.aspect) / l.aspect;
+    if (err < bestErr) { bestErr = err; best = l; }
+  }
+  // Beyond a few percent it is not one of ours; caller decides what to do.
+  return bestErr <= 0.04 ? best : null;
+}
+
+// ---------------------------------------------------------------------------
+// Projection, shared by the viewer's shader and the stitcher's gutter builder
+// ---------------------------------------------------------------------------
+
+// Face-local UV in [0,1] -> unnormalised direction. Inverse of gnomonicUV.
+export function faceUvToDir(faceIndex, u, v) {
+  const a = u * 2 - 1, b = v * 2 - 1;
+  switch (faceIndex) {
+    case 0: return [-1,  b, -a];
+    case 1: return [ 1,  b,  a];
+    case 2: return [ a,  1, -b];
+    case 3: return [ a, -1,  b];
+    case 4: return [ a,  b,  1];
+    default:return [-a,  b, -1];
+  }
+}
+
+// Direction -> { faceIndex, u, v }. Forward gnomonic projection.
+export function dirToFaceUv(x, y, z) {
+  const ax = Math.abs(x), ay = Math.abs(y), az = Math.abs(z);
+  let faceIndex, a, b;
+  if (ax >= ay && ax >= az) {
+    if (x < 0) { faceIndex = 0; a = -z / ax; b =  y / ax; }
+    else       { faceIndex = 1; a =  z / ax; b =  y / ax; }
+  } else if (ay >= az) {
+    if (y > 0) { faceIndex = 2; a =  x / ay; b = -z / ay; }
+    else       { faceIndex = 3; a =  x / ay; b =  z / ay; }
+  } else {
+    if (z > 0) { faceIndex = 4; a =  x / az; b =  y / az; }
+    else       { faceIndex = 5; a = -x / az; b =  y / az; }
+  }
+  return { faceIndex, u: a * 0.5 + 0.5, v: b * 0.5 + 0.5 };
+}
+
+// ---------------------------------------------------------------------------
+// GLSL
+// ---------------------------------------------------------------------------
+
+const GLSL_HELPERS = `
+  vec2 rotateUV(vec2 uv, float angleDeg) {
+    float a = radians(angleDeg); float s = sin(a), c = cos(a);
+    vec2 p = uv - 0.5; return vec2(p.x * c - p.y * s, p.x * s + p.y * c) + 0.5;
+  }
+`;
+
+const GLSL_5X3 = `
+  vec2 getGrid(float col, float row, vec2 localUv) { return vec2((col + localUv.x) / 5.0, (2.0 - row + localUv.y) / 3.0); }
+  vec4 sampleAtlas(sampler2D tex, int face, vec2 local) {
+    if (face == 4) return texture2D(tex, getGrid(1.0, 1.0, local));
+    if (face == 0) return texture2D(tex, getGrid(2.0, 1.0, local));
+    if (face == 5) return texture2D(tex, getGrid(3.0, 1.0, local));
+
+    if (face == 1) {
+      vec4 c4 = texture2D(tex, getGrid(4.0, 1.0, local));
+      vec4 c0 = texture2D(tex, getGrid(0.0, 1.0, local));
+      return mix(c4, c0, smoothstep(0.25, 0.75, local.x));
+    }
+
+    // Pole faces: blend the four rotated copies by quadrant, so the bilinear
+    // neighbour at each edge is the wall that edge actually adjoins.
+    float d1 = local.x - local.y;
+    float d2 = (1.0 - local.x) - local.y;
+    float t1 = smoothstep(-0.1, 0.1, d1);
+    float t2 = smoothstep(-0.1, 0.1, d2);
+
+    float wBottom = t1 * t2;
+    float wTop    = (1.0 - t1) * (1.0 - t2);
+    float wLeft   = (1.0 - t1) * t2;
+    float wRight  = t1 * (1.0 - t2);
+
+    if (face == 2) {
+      vec4 cFront = texture2D(tex, getGrid(1.0, 0.0, local));
+      vec4 cBack  = texture2D(tex, getGrid(3.0, 0.0, rotateUV(local, 180.0)));
+      vec4 cLeft  = texture2D(tex, getGrid(0.0, 0.0, rotateUV(local, 90.0)));
+      vec4 cRight = texture2D(tex, getGrid(2.0, 0.0, rotateUV(local, -90.0)));
+      return cFront * wBottom + cBack * wTop + cLeft * wLeft + cRight * wRight;
+    }
+
+    if (face == 3) {
+      vec4 cFront = texture2D(tex, getGrid(1.0, 2.0, local));
+      vec4 cBack  = texture2D(tex, getGrid(3.0, 2.0, rotateUV(local, 180.0)));
+      vec4 cLeft  = texture2D(tex, getGrid(0.0, 2.0, rotateUV(local, -90.0)));
+      vec4 cRight = texture2D(tex, getGrid(2.0, 2.0, rotateUV(local, 90.0)));
+      return cFront * wTop + cBack * wBottom + cLeft * wLeft + cRight * wRight;
+    }
+    return vec4(0.0);
+  }
+`;
+
+// GUTTER_FRAC is filled in per atlas, since it depends on the face size the
+// atlas was written at.
+const GLSL_3X2 = `
+  uniform float uGutterFrac;
+  vec2 getGrid(float col, float row, vec2 localUv) { return vec2((col + localUv.x) / 3.0, (1.0 - row + localUv.y) / 2.0); }
+  vec4 sampleAtlas(sampler2D tex, int face, vec2 local) {
+    // Inset into the cell's content area; the border is neighbour bleed.
+    vec2 inset = mix(vec2(uGutterFrac), vec2(1.0 - uGutterFrac), local);
+    if (face == 1) return texture2D(tex, getGrid(0.0, 0.0, inset));
+    if (face == 4) return texture2D(tex, getGrid(1.0, 0.0, inset));
+    if (face == 0) return texture2D(tex, getGrid(2.0, 0.0, inset));
+    if (face == 5) return texture2D(tex, getGrid(0.0, 1.0, inset));
+    if (face == 2) return texture2D(tex, getGrid(1.0, 1.0, inset));
+    return texture2D(tex, getGrid(2.0, 1.0, inset));
+  }
+`;
+
+export function sampleAtlasGlsl(layoutId) {
+  return GLSL_HELPERS + (layoutId === '3x2' ? GLSL_3X2 : GLSL_5X3);
+}
+
+// True when the layout's shader declares a uGutterFrac uniform.
+export function layoutUsesGutter(layoutId) {
+  return layoutId === '3x2';
+}

--- a/cube/index.html
+++ b/cube/index.html
@@ -467,13 +467,20 @@
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(80, window.innerWidth / window.innerHeight, 0.1, 500); 
     const renderer = new THREE.WebGLRenderer({ antialias: false });
+    // Cap the ratio: at 3x on a phone this shades 9 pixels per CSS pixel across
+    // ~200k triangles per mesh, for no visible gain over 2x.
+    const pixelRatio = Math.min(window.devicePixelRatio, 2);
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setPixelRatio(pixelRatio);
     container.appendChild(renderer.domElement);
+
+    // Largest texture this GPU will accept. Mobile parts commonly cap at 4096,
+    // where an oversized upload silently fails or drops the context.
+    const maxTextureSize = renderer.capabilities.maxTextureSize;
 
     // --- SPHEREIFIED CUBE GEOMETRY ---
     const geometry = new THREE.BoxGeometry(100, 100, 100, 128, 128, 128);
-    geometry.scale(-1, 1, 1); 
+    geometry.scale(-1, 1, 1);
     const pos = geometry.attributes.position;
     const vTemp = new THREE.Vector3();
     for(let i=0; i<pos.count; i++) {
@@ -481,19 +488,16 @@
         vTemp.normalize().multiplyScalar(50);
         pos.setXYZ(i, vTemp.x, vTemp.y, vTemp.z);
     }
-    geometry.computeVertexNormals();
-    
+    // The shaders read neither normals nor the built-in uv (vUv is derived from
+    // position via gnomonicUV), so both are dead weight on ~99k vertices per mesh.
+    geometry.deleteAttribute('normal');
+    geometry.deleteAttribute('uv');
+
     // BG sphere at radius 56 — well outside max fg displacement so there is always
     // solid bg geometry visible behind any fg tear or displacement gap.
-    const bgGeometry = new THREE.BoxGeometry(100, 100, 100, 128, 128, 128);
-    bgGeometry.scale(-1, 1, 1);
-    const bgPos = bgGeometry.attributes.position;
-    for(let i=0; i<bgPos.count; i++) {
-        vTemp.fromBufferAttribute(bgPos, i);
-        vTemp.normalize().multiplyScalar(56);
-        bgPos.setXYZ(i, vTemp.x, vTemp.y, vTemp.z);
-    }
-    bgGeometry.computeVertexNormals();
+    // Cloning and scaling beats re-running the sphereification loop on the CPU.
+    const bgGeometry = geometry.clone();
+    bgGeometry.scale(56 / 50, 56 / 50, 56 / 50);
     
     const dummyDepthData = new Uint8Array([0, 0, 0, 255]); 
     const dummyDepthTex = new THREE.DataTexture(dummyDepthData, 1, 1, THREE.RGBAFormat);
@@ -875,8 +879,13 @@
     const transitionScene = new THREE.Scene();
     const transitionCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
     
-    let rtOld = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight, { type: THREE.HalfFloatType });
-    let rtNew = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight, { type: THREE.HalfFloatType });
+    // Match the drawing buffer, not the CSS size — otherwise the transition
+    // composites a low-res buffer onto a hi-dpi canvas and looks soft throughout.
+    const rtWidth  = () => Math.floor(window.innerWidth  * pixelRatio);
+    const rtHeight = () => Math.floor(window.innerHeight * pixelRatio);
+
+    let rtOld = new THREE.WebGLRenderTarget(rtWidth(), rtHeight(), { type: THREE.HalfFloatType });
+    let rtNew = new THREE.WebGLRenderTarget(rtWidth(), rtHeight(), { type: THREE.HalfFloatType });
 
     const FRAG_BLOCK = `
       uniform sampler2D tOld;
@@ -928,21 +937,33 @@
       }
     `;
 
-    const transitionMat = new THREE.ShaderMaterial({
-      uniforms: {
-        tOld:      { value: null },
-        tNew:      { value: null },
-        tDepthNew: { value: dummyDepthTex },
-        uProgress: { value: 0 },
-        uAspect:   { value: 1.0 },
-        uDepthBias:{ value: 0.6 }
-      },
-      vertexShader: `varying vec2 vUv; void main() { vUv = uv; gl_Position = vec4(position, 1.0); }`,
-      fragmentShader: FRAG_BLOCK,
-      depthTest: false,
-      depthWrite: false
-    });
-    transitionScene.add(new THREE.Mesh(new THREE.PlaneGeometry(2, 2), transitionMat));
+    // Two materials sharing one uniforms object, rather than swapping
+    // fragmentShader + needsUpdate on a single material — that forced a shader
+    // recompile at the start of every transition, which stalls on mobile.
+    const transitionUniforms = {
+      tOld:      { value: null },
+      tNew:      { value: null },
+      tDepthNew: { value: dummyDepthTex },
+      uProgress: { value: 0 },
+      uAspect:   { value: 1.0 },
+      uDepthBias:{ value: 0.6 }
+    };
+    const makeTransitionMat = (fragmentShader) => {
+      const m = new THREE.ShaderMaterial({
+        uniforms: transitionUniforms,
+        vertexShader: `varying vec2 vUv; void main() { vUv = uv; gl_Position = vec4(position, 1.0); }`,
+        fragmentShader,
+        depthTest: false,
+        depthWrite: false
+      });
+      m.uniforms = transitionUniforms; // share, don't clone
+      return m;
+    };
+    const transitionMats = { block: makeTransitionMat(FRAG_BLOCK), fade: makeTransitionMat(FRAG_FADE) };
+    const setTransitionUniform = (name, value) => { transitionUniforms[name].value = value; };
+
+    const transitionMesh = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), transitionMats.block);
+    transitionScene.add(transitionMesh);
 
     let pendingTransitionDepth = null;
 
@@ -960,29 +981,44 @@
         return toDispose;
     }
 
-    function upscaleDepthTex(dTex, targetWidth, targetHeight) {
-        if (!dTex || dTex === dummyDepthTex || !dTex.image) return dTex;
-        const dImg = dTex.image;
-        if (dImg.width === targetWidth && dImg.height === targetHeight) return dTex;
+    // Downscale anything the GPU won't accept. J'nanin's "6K" faces are 6144px,
+    // which exceeds the 4096 limit common on mobile parts — the upload then fails
+    // silently (black faces) or drops the context. Downscaling is preferable to
+    // either, and is a no-op on desktop GPUs that can take the full size.
+    function fitToGpu(tex) {
+        const img = tex && tex.image;
+        if (!img || (img.width <= maxTextureSize && img.height <= maxTextureSize)) return tex;
 
+        const scale = maxTextureSize / Math.max(img.width, img.height);
         const canvas = document.createElement('canvas');
-        canvas.width = targetWidth;
-        canvas.height = targetHeight;
+        canvas.width  = Math.max(1, Math.floor(img.width  * scale));
+        canvas.height = Math.max(1, Math.floor(img.height * scale));
         const ctx = canvas.getContext('2d');
         ctx.imageSmoothingEnabled = true;
         ctx.imageSmoothingQuality = 'high';
-        ctx.drawImage(dImg, 0, 0, targetWidth, targetHeight);
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        console.info(`Downscaled ${img.width}x${img.height} texture to ${canvas.width}x${canvas.height} (GPU limit ${maxTextureSize}).`);
 
-        const newTex = new THREE.CanvasTexture(canvas);
-        newTex.colorSpace = THREE.NoColorSpace;
-        newTex.minFilter = THREE.LinearFilter;
-        newTex.magFilter = THREE.LinearFilter;
-        newTex.wrapS = THREE.ClampToEdgeWrapping;
-        newTex.wrapT = THREE.ClampToEdgeWrapping;
-        newTex.generateMipmaps = false;
+        const fitted = new THREE.CanvasTexture(canvas);
+        fitted.colorSpace = tex.colorSpace;
+        tex.dispose();
+        return fitted;
+    }
 
-        dTex.dispose();
-        return newTex;
+    // Depth is sampled with normalised UVs, so its resolution never had to match
+    // the colour map. This used to resample every depth map onto a canvas at the
+    // colour map's size — a full-size canvas plus a CanvasTexture per face, for
+    // no visual difference. Now we just apply the sampling settings in place.
+    function prepareDepthTex(dTex) {
+        if (!dTex || dTex === dummyDepthTex || !dTex.image) return dTex;
+        dTex.colorSpace = THREE.NoColorSpace;
+        dTex.minFilter = THREE.LinearFilter;
+        dTex.magFilter = THREE.LinearFilter;
+        dTex.wrapS = THREE.ClampToEdgeWrapping;
+        dTex.wrapT = THREE.ClampToEdgeWrapping;
+        dTex.generateMipmaps = false;
+        dTex.needsUpdate = true;
+        return dTex;
     }
 
     function getCubemapUrls(loc, version, fetchDepth = false) {
@@ -1052,11 +1088,10 @@
       playOrCrossfadeAudio(currentLocation.audio);
 
       renderer.setRenderTarget(rtOld); renderer.render(scene, camera); renderer.setRenderTarget(null);
-      transitionMat.uniforms.tOld.value = rtOld.texture;
-      transitionMat.uniforms.tNew.value = rtNew.texture;
-      transitionMat.uniforms.uProgress.value = 0;
-      transitionMat.fragmentShader = mode === 'block' ? FRAG_BLOCK : FRAG_FADE;
-      transitionMat.needsUpdate = true;
+      setTransitionUniform('tOld', rtOld.texture);
+      setTransitionUniform('tNew', rtNew.texture);
+      setTransitionUniform('uProgress', 0);
+      transitionMesh.material = mode === 'block' ? transitionMats.block : transitionMats.fade;
 
       const targetVersion = currentLocation.versions[currentVersionIndex];
       const isVideo = targetVersion.type === 'video-5x3';
@@ -1082,9 +1117,7 @@
                     try { return await textureLoader.loadAsync(url); } 
                     catch(e) { console.warn("Missing depth map:", url); return dummyDepthTex; }
                 }));
-                const faceW = Math.floor(sourceVideo.videoWidth / 5);
-                const faceH = Math.floor(sourceVideo.videoHeight / 3);
-                depthTextures = loadedDepths.map(dTex => upscaleDepthTex(dTex, faceW, faceH));
+                depthTextures = loadedDepths.map(prepareDepthTex);
             }
             
             const currentSliderVal = hasActiveDepth ? (parseFloat(document.getElementById('displacement-slider').value) / 100.0) : 0.0;
@@ -1117,6 +1150,7 @@
             const processAtlasTex = (tex, isColor) => {
                 if (tex === defaultCustomTex || tex === dummyDepthTex) return tex;
                 tex.colorSpace = isColor ? THREE.SRGBColorSpace : THREE.NoColorSpace;
+                tex = fitToGpu(tex);
                 tex.generateMipmaps = false; tex.minFilter = THREE.LinearFilter; tex.magFilter = THREE.LinearFilter;
                 tex.wrapS = THREE.ClampToEdgeWrapping; tex.wrapT = THREE.ClampToEdgeWrapping;
                 tex.needsUpdate = true;
@@ -1128,17 +1162,8 @@
             const bgC = processAtlasTex(loaded[2], true);
             let bgD = loaded[3];
             
-            if (customMaps.fgColor && customMaps.fgDepth) {
-                const fw = (fgC !== defaultCustomTex && fgC.image) ? fgC.image.width : 1;
-                const fh = (fgC !== defaultCustomTex && fgC.image) ? fgC.image.height : 1;
-                fgD = upscaleDepthTex(fgD, fw, fh);
-            } else { fgD = processAtlasTex(fgD, false); }
-            
-            if (customMaps.bgColor && customMaps.bgDepth) {
-                const bw = (bgC !== defaultCustomTex && bgC.image) ? bgC.image.width : 1;
-                const bh = (bgC !== defaultCustomTex && bgC.image) ? bgC.image.height : 1;
-                bgD = upscaleDepthTex(bgD, bw, bh);
-            } else { bgD = processAtlasTex(bgD, false); }
+            fgD = prepareDepthTex(fgD);
+            bgD = prepareDepthTex(bgD);
 
             if (loadId !== currentLoadId) return;
 
@@ -1198,11 +1223,7 @@
                     catch(e) { console.warn("Missing depth map:", url); return dummyDepthTex; }
                 }));
                 
-                depthTextures = loadedDepths.map((dTex, i) => {
-                    const cw = loadedColors[i].image ? loadedColors[i].image.width : 1024;
-                    const ch = loadedColors[i].image ? loadedColors[i].image.height : 1024;
-                    return upscaleDepthTex(dTex, cw, ch);
-                });
+                depthTextures = loadedDepths.map(prepareDepthTex);
             } else {
                 depthControlsContainer.style.display = 'none';
             }
@@ -1214,8 +1235,8 @@
             bgCubeMesh.visible = false;
             
             fgCubeMesh.material.forEach((mat, i) => {
-              const tex = loadedColors[i];
-              tex.colorSpace = THREE.SRGBColorSpace;
+              loadedColors[i].colorSpace = THREE.SRGBColorSpace;
+              const tex = loadedColors[i] = fitToGpu(loadedColors[i]);
               tex.minFilter = THREE.LinearMipmapLinearFilter;
               tex.magFilter = THREE.LinearFilter;
               tex.generateMipmaps = true;
@@ -1254,9 +1275,9 @@
       }
 
       if (mode === 'block' && pendingTransitionDepth) {
-        transitionMat.uniforms.tDepthNew.value = pendingTransitionDepth;
+        setTransitionUniform('tDepthNew', pendingTransitionDepth);
       } else {
-        transitionMat.uniforms.tDepthNew.value = dummyDepthTex;
+        setTransitionUniform('tDepthNew', dummyDepthTex);
       }
 
       const duration = mode === 'block' ? 1400 : 600;
@@ -1264,7 +1285,7 @@
       function animateTween(now) {
         if (loadId !== currentLoadId) return;
         const p = Math.min((now - startTime) / duration, 1);
-        transitionMat.uniforms.uProgress.value = p;
+        setTransitionUniform('uProgress', p);
         if (p < 1) requestAnimationFrame(animateTween);
         else {
           isTransitioning = false;
@@ -1272,7 +1293,7 @@
             pendingTransitionDepth.dispose();
             pendingTransitionDepth = null;
           }
-          transitionMat.uniforms.tDepthNew.value = dummyDepthTex;
+          setTransitionUniform('tDepthNew', dummyDepthTex);
         }
       }
       requestAnimationFrame(animateTween);
@@ -1359,8 +1380,8 @@
     window.addEventListener('resize', () => {
       camera.aspect = window.innerWidth / window.innerHeight; camera.updateProjectionMatrix();
       renderer.setSize(window.innerWidth, window.innerHeight);
-      rtOld.setSize(window.innerWidth, window.innerHeight); rtNew.setSize(window.innerWidth, window.innerHeight);
-      transitionMat.uniforms.uAspect.value = window.innerWidth / window.innerHeight;
+      rtOld.setSize(rtWidth(), rtHeight()); rtNew.setSize(rtWidth(), rtHeight());
+      setTransitionUniform('uAspect', window.innerWidth / window.innerHeight);
     });
 
     function updateUI() {
@@ -1399,8 +1420,13 @@
       }
     }
 
-    transitionMat.uniforms.uAspect.value = window.innerWidth / window.innerHeight;
-    updateUI(); loadPanorama('block'); render(); 
+    setTransitionUniform('uAspect', window.innerWidth / window.innerHeight);
+    updateUI();
+    // Compile the currently bound programs up front so the shader build doesn't
+    // land inside the first rendered frame.
+    renderer.compile(scene, camera);
+    renderer.compile(transitionScene, transitionCamera);
+    loadPanorama('block'); render();
 
   </script>
 </body>

--- a/cube/index.html
+++ b/cube/index.html
@@ -119,6 +119,21 @@
     #gyro-toggle { display: inline-flex; align-items: center; justify-content: center; }
     #video-toggle { font-size: 14px; }
     
+    #load-error {
+      position: fixed; left: 50%; transform: translateX(-50%);
+      top: calc(env(safe-area-inset-top, 0px) + 50%);
+      z-index: 1002; display: none; align-items: center; gap: 12px;
+      background: rgba(40, 10, 10, 0.92); border: 1px solid rgba(255, 120, 120, 0.4);
+      color: #ffdcdc; padding: 12px 16px; border-radius: 8px; font-size: 13px;
+      max-width: 85vw; text-align: center; line-height: 1.4;
+      backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+    }
+    #load-error.active { display: flex; }
+    #load-error button {
+      background: rgba(255,255,255,0.15); border: 1px solid rgba(255,255,255,0.25);
+      color: #fff; font-size: 12px; padding: 5px 12px; flex-shrink: 0;
+    }
+
     #loader {
       position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 1001;
       width: 40px; height: 40px; border: 4px solid rgba(255,255,255,0.1); border-top-color: #fff; border-radius: 50%;
@@ -142,6 +157,11 @@
 
   <div id="viewer-container"></div>
   <div id="loader"></div>
+  <div id="load-error" role="alert" aria-live="assertive">
+    <span id="load-error-msg"></span>
+    <button id="load-error-retry" type="button">Retry</button>
+    <button id="load-error-dismiss" type="button" aria-label="Dismiss error">&times;</button>
+  </div>
 
   <div class="ui-container">
     <div class="controls-row">
@@ -223,14 +243,17 @@
   <script type="module">
     import * as THREE from 'three';
 
-    const rawUrl = 'https://raw.githubusercontent.com/e-z-g/e-z-g.github.io/main/';
+    // Assets live next to this page. Loading them relatively (rather than from
+    // raw.githubusercontent.com) keeps them on the Pages CDN, drops a cross-origin
+    // handshake, avoids raw's throttling, and lets the viewer run from a local server.
+    const rawUrl = './';
 
     const locations = [
       {
         name: 'Amateria',
-        baseUrl: rawUrl + 'cube/amateria/',
+        baseUrl: rawUrl + 'amateria/',
         type: 'side-numbered',
-        audio: rawUrl + 'cube/amateria/audio_amateria.mp3',
+        audio: rawUrl + 'amateria/audio_amateria.mp3',
         hasDepth: false,
         versions: [
           { label: 'Original', suffix: '_orig.jpeg' },
@@ -239,20 +262,18 @@
       },
       {
         name: 'Voltaic',
-        baseUrl: rawUrl + 'cube/voltaic/',
+        baseUrl: rawUrl + 'voltaic/',
         type: 'voltaic',
-        audio: rawUrl + 'cube/amateria/audio_amateria.mp3',
+        audio: rawUrl + 'amateria/audio_amateria.mp3',
         hasDepth: true,
-        depthSuffix: '-depth.jpeg', 
+        depthSuffix: '-depth.jpeg',
         versions: [
-          { label: 'Original', suffix: '_orig.jpeg' },
-          { label: 'Alt (IMG)', type: 'img-seq' },
-          { label: 'Video (5x3)', type: 'video-5x3', url: rawUrl + 'cubemapvr/voltaic_video.mp4' }
+          { label: 'Original', suffix: '_orig.jpeg' }
         ]
       },
       {
         name: "J'nanin",
-        baseUrl: rawUrl + 'cube/jnanin/',
+        baseUrl: rawUrl + 'jnanin/',
         type: 'classic-leis',
         audio: null,
         hasDepth: false,
@@ -333,7 +354,7 @@
       } else {
         audioSystem.isMuted = false; audioToggleBtn.classList.add('active');
         if (audioSystem.currentUrl && (!audioSystem.active.src || audioSystem.active.src === '')) playOrCrossfadeAudio(audioSystem.currentUrl);
-        else if (audioSystem.active.paused) audioSystem.active.play().catch(e => console.warn(e));
+        else if (audioSystem.active.src && audioSystem.active.paused) audioSystem.active.play().catch(e => console.warn(e));
         audioSystem.active.volume = audioSystem.masterVolume;
       }
       targetDniState = dniStates[val];
@@ -344,8 +365,28 @@
     volumeSlider.addEventListener('input', (e) => setVolume(e.target.value));
     largeVolumeSlider.addEventListener('input', (e) => setVolume(e.target.value));
 
+    // Ramp a media element's volume to a target over ~1s, then run onDone.
+    function rampVolume(el, from, to, onDone) {
+      if (audioSystem.fadeInterval) clearInterval(audioSystem.fadeInterval);
+      let step = 0; const steps = 20;
+      audioSystem.fadeInterval = setInterval(() => {
+        step++; const progress = step / steps;
+        el.volume = Math.max(0, Math.min(1, from + (to - from) * progress));
+        if (step >= steps) { clearInterval(audioSystem.fadeInterval); if (onDone) onDone(); }
+      }, 50);
+    }
+
+    // Locations with `audio: null` used to leave the previous track playing,
+    // because playOrCrossfadeAudio bails on a falsy URL. Fade out instead.
+    function fadeOutAudio() {
+      audioSystem.currentUrl = null;
+      if (!audioSystem.active.src) return;
+      const el = audioSystem.active;
+      rampVolume(el, el.volume, 0, () => { el.pause(); el.removeAttribute('src'); });
+    }
+
     function playOrCrossfadeAudio(newUrl) {
-      if (!newUrl) return;
+      if (!newUrl) { fadeOutAudio(); return; }
       if (audioSystem.currentUrl === newUrl && audioSystem.active.src) {
         if (!audioSystem.isMuted && audioSystem.masterVolume > 0 && audioSystem.active.paused) audioSystem.active.play().catch(e=>console.warn(e));
         return;
@@ -860,9 +901,10 @@
         vec2 blockCenter = (blockId + 0.5) / vec2(gridCols, gridRows);
         float depthVal = texture2D(tDepthNew, blockCenter).r;
 
-        float weightedNoise = noise;
-        float depthWeighted = noise * (1.0 - uDepthBias) + (noise * 0.5 + depthVal * 0.5) * uDepthBias;
-        float threshold = mix(weightedNoise, depthWeighted, uDepthBias);
+        // Blend the block's reveal threshold from pure noise toward depth-ordered.
+        // (This used to apply uDepthBias twice, once inside depthWeighted and again
+        // in the mix, which flattened the bias curve.)
+        float threshold = mix(noise, noise * 0.5 + depthVal * 0.5, uDepthBias);
 
         if (uProgress > threshold) {
           gl_FragColor = texture2D(tNew, vUv);
@@ -877,10 +919,7 @@
     const FRAG_FADE = `
       uniform sampler2D tOld;
       uniform sampler2D tNew;
-      uniform sampler2D tDepthNew;
       uniform float uProgress;
-      uniform float uAspect;
-      uniform float uDepthBias;
       varying vec2 vUv;
       void main() {
         gl_FragColor = mix(texture2D(tOld, vUv), texture2D(tNew, vUv), smoothstep(0.0, 1.0, uProgress));
@@ -889,15 +928,11 @@
       }
     `;
 
-    const dummyTransDepthData = new Uint8Array([0, 0, 0, 255]);
-    const dummyTransDepthTex  = new THREE.DataTexture(dummyTransDepthData, 1, 1, THREE.RGBAFormat);
-    dummyTransDepthTex.needsUpdate = true;
-
     const transitionMat = new THREE.ShaderMaterial({
       uniforms: {
         tOld:      { value: null },
         tNew:      { value: null },
-        tDepthNew: { value: dummyTransDepthTex },
+        tDepthNew: { value: dummyDepthTex },
         uProgress: { value: 0 },
         uAspect:   { value: 1.0 },
         uDepthBias:{ value: 0.6 }
@@ -955,11 +990,7 @@
       const type = fetchDepth ? loc.type : ((typeof version === 'object' && version.type) ? version.type : loc.type);
       
       let p;
-      if (type === 'img-seq') { 
-          const b = rawUrl + 'cubemapvr/'; 
-          p = { front: b+'IMG_5228.jpeg', bottom: b+'IMG_5229.jpeg', back: b+'IMG_5230.jpeg', left: b+'IMG_5232.jpeg', right: b+'IMG_5231.jpeg', top: b+'IMG_5233.jpeg' }; 
-      } 
-      else if (type === 'side-numbered') { p = { front: loc.baseUrl+'MAWWnodes-8'+s, bottom: loc.baseUrl+'MAWWnodes-9'+s, back: loc.baseUrl+'MAWWnodes-10'+s, right: loc.baseUrl+'MAWWnodes-11'+s, left: loc.baseUrl+'MAWWnodes-12'+s, top: loc.baseUrl+'MAWWnodes-13'+s }; } 
+      if (type === 'side-numbered') { p = { front: loc.baseUrl+'MAWWnodes-8'+s, bottom: loc.baseUrl+'MAWWnodes-9'+s, back: loc.baseUrl+'MAWWnodes-10'+s, right: loc.baseUrl+'MAWWnodes-11'+s, left: loc.baseUrl+'MAWWnodes-12'+s, top: loc.baseUrl+'MAWWnodes-13'+s }; }
       else if (type === 'voltaic') { 
         p = { left: loc.baseUrl+'ENCHnodes-281'+s, front: loc.baseUrl+'ENCHnodes-277'+s, right: loc.baseUrl+'ENCHnodes-280'+s, back: loc.baseUrl+'ENCHnodes-279'+s, top: loc.baseUrl+'ENCHnodes-282'+s, bottom: loc.baseUrl+'ENCHnodes-278'+s }; 
       } 
@@ -969,9 +1000,9 @@
     }
 
     function buildTransitionDepthTex(depthTextures) {
-      if (!depthTextures) return dummyTransDepthTex;
+      if (!depthTextures) return dummyDepthTex;
       const frontTex = depthTextures[4] || depthTextures[0];
-      if (!frontTex || frontTex === dummyDepthTex || !frontTex.image) return dummyTransDepthTex;
+      if (!frontTex || frontTex === dummyDepthTex || !frontTex.image) return dummyDepthTex;
       const SIZE = 64;
       const canvas = document.createElement('canvas');
       canvas.width = SIZE; canvas.height = SIZE;
@@ -986,12 +1017,39 @@
       return tex;
     }
 
+    // --- Load error surfacing ---
+    // Failures used to be console-only: the spinner vanished and the previous
+    // scene just stayed put with no explanation.
+    const loadErrorEl = document.getElementById('load-error');
+    let pendingRetry = null;
+
+    function showLoadError(locationName, retryFn) {
+      document.getElementById('load-error-msg').textContent =
+        `Couldn't load ${locationName}. Check your connection and try again.`;
+      pendingRetry = retryFn;
+      loadErrorEl.classList.add('active');
+    }
+    function hideLoadError() {
+      loadErrorEl.classList.remove('active');
+      pendingRetry = null;
+    }
+    document.getElementById('load-error-retry').addEventListener('click', () => {
+      const retry = pendingRetry;
+      hideLoadError();
+      if (retry) retry();
+    });
+    document.getElementById('load-error-dismiss').addEventListener('click', hideLoadError);
+
     async function loadPanorama(mode = 'block') {
       if (isTransitioning) return;
       const loadId = ++currentLoadId;
       isTransitioning = true;
+      // Tracks whether we reached the tween, which then owns clearing isTransitioning.
+      let handedOffToTween = false;
       document.getElementById('loader').style.display = 'block';
-      if (currentLocation.audio) playOrCrossfadeAudio(currentLocation.audio);
+      hideLoadError();
+      // Always call: a location with `audio: null` needs the previous track faded out.
+      playOrCrossfadeAudio(currentLocation.audio);
 
       renderer.setRenderTarget(rtOld); renderer.render(scene, camera); renderer.setRenderTarget(null);
       transitionMat.uniforms.tOld.value = rtOld.texture;
@@ -1180,36 +1238,41 @@
           }
           
           oldTextures.forEach(t => t.dispose());
+          // Load body completed; the tween below now owns isTransitioning.
+          handedOffToTween = true;
 
       } catch (err) {
           console.error("Failed to load panorama:", err);
-          isTransitioning = false;
-          document.getElementById('loader').style.display = 'none';
+          showLoadError(currentLocation.name, () => loadPanorama(mode));
           return;
+      } finally {
+          // Every exit path clears the spinner. isTransitioning is only left set
+          // when the tween below has taken ownership of it — previously a stale-load
+          // return skipped both and locked the viewer permanently.
+          document.getElementById('loader').style.display = 'none';
+          if (!handedOffToTween) isTransitioning = false;
       }
 
       if (mode === 'block' && pendingTransitionDepth) {
         transitionMat.uniforms.tDepthNew.value = pendingTransitionDepth;
       } else {
-        transitionMat.uniforms.tDepthNew.value = dummyTransDepthTex;
+        transitionMat.uniforms.tDepthNew.value = dummyDepthTex;
       }
-
-      document.getElementById('loader').style.display = 'none';
 
       const duration = mode === 'block' ? 1400 : 600;
       const startTime = performance.now();
       function animateTween(now) {
-        if (loadId !== currentLoadId) return; 
+        if (loadId !== currentLoadId) return;
         const p = Math.min((now - startTime) / duration, 1);
         transitionMat.uniforms.uProgress.value = p;
         if (p < 1) requestAnimationFrame(animateTween);
         else {
           isTransitioning = false;
-          if (pendingTransitionDepth && pendingTransitionDepth !== dummyTransDepthTex) {
+          if (pendingTransitionDepth && pendingTransitionDepth !== dummyDepthTex) {
             pendingTransitionDepth.dispose();
             pendingTransitionDepth = null;
           }
-          transitionMat.uniforms.tDepthNew.value = dummyTransDepthTex;
+          transitionMat.uniforms.tDepthNew.value = dummyDepthTex;
         }
       }
       requestAnimationFrame(animateTween);
@@ -1305,6 +1368,12 @@
       if (locSelect.options.length === 0) {
         locations.forEach((loc, i) => { const opt = document.createElement('option'); opt.value = i; opt.textContent = loc.name; if (loc === currentLocation) opt.selected = true; locSelect.appendChild(opt); });
         locSelect.onchange = (e) => {
+          // loadPanorama refuses to start mid-transition. Without this guard the
+          // select and the rebuilt controls moved on while the scene did not.
+          if (isTransitioning) {
+            e.target.value = locations.indexOf(currentLocation);
+            return;
+          }
           const isLocChange = locations[e.target.value] !== currentLocation;
           currentLocation = locations[e.target.value]; currentVersionIndex = 0;
           updateUI(); loadPanorama(isLocChange ? 'block' : 'fade');

--- a/cube/index.html
+++ b/cube/index.html
@@ -184,6 +184,9 @@
               + 3D Decal Video <input type="file" id="upload-decal" accept="video/*" style="display:none;">
             </label>
         </div>
+        <a class="upload-btn" href="./stitcher.html" style="text-decoration:none; display:block;">
+          Build an atlas from 6 faces →
+        </a>
       </div>
     </div>
     
@@ -242,6 +245,7 @@
 
   <script type="module">
     import * as THREE from 'three';
+    import { sampleAtlasGlsl, detectLayout, layoutUsesGutter, GUTTER_PX, LAYOUTS } from './atlas-layout.js';
 
     // Assets live next to this page. Loading them relatively (rather than from
     // raw.githubusercontent.com) keeps them on the Pages CDN, drops a cross-origin
@@ -284,7 +288,7 @@
         ]
       },
       {
-        name: 'Custom (5x3 LDI Upload)',
+        name: 'Custom (LDI Upload)',
         type: 'custom',
         audio: null,
         hasDepth: false,
@@ -334,6 +338,51 @@
     setupUploader('fg-depth', 'fgDepth');
     setupUploader('bg-color', 'bgColor');
     setupUploader('bg-depth', 'bgDepth');
+
+    // --- Handoff from the stitcher ---
+    // The stitcher stashes freshly built atlases in IndexedDB and sends the user
+    // here, so an atlas doesn't have to be downloaded and re-uploaded by hand.
+    const HANDOFF_DB = 'cubemap-handoff', HANDOFF_STORE = 'atlases';
+    const HANDOFF_SLOTS = {
+      'fg-color': 'fgColor', 'fg-depth': 'fgDepth',
+      'bg-color': 'bgColor', 'bg-depth': 'bgDepth',
+    };
+
+    async function takeHandoffAtlases() {
+      if (!window.indexedDB) return false;
+      let db;
+      try {
+        db = await new Promise((resolve, reject) => {
+          const req = indexedDB.open(HANDOFF_DB, 1);
+          req.onupgradeneeded = () => req.result.createObjectStore(HANDOFF_STORE);
+          req.onsuccess = () => resolve(req.result);
+          req.onerror = () => reject(req.error);
+        });
+      } catch (e) { return false; }
+
+      const found = await new Promise((resolve) => {
+        const out = {};
+        const tx = db.transaction(HANDOFF_STORE, 'readwrite');
+        const store = tx.objectStore(HANDOFF_STORE);
+        for (const slot of Object.keys(HANDOFF_SLOTS)) {
+          const get = store.get(slot);
+          get.onsuccess = () => { if (get.result) { out[slot] = get.result; store.delete(slot); } };
+        }
+        tx.oncomplete = () => resolve(out);
+        tx.onerror = () => resolve(out);
+      });
+      db.close();
+
+      let any = false;
+      for (const [slot, blob] of Object.entries(found)) {
+        const mapKey = HANDOFF_SLOTS[slot];
+        if (customMaps[mapKey]) URL.revokeObjectURL(customMaps[mapKey]);
+        customMaps[mapKey] = URL.createObjectURL(blob);
+        document.getElementById(`lbl-upload-${slot}`).classList.add('active');
+        any = true;
+      }
+      return any;
+    }
 
     // --- Audio System ---
     const audioSystem = { active: new Audio(), fading: new Audio(), isMuted: true, masterVolume: 0, currentUrl: currentLocation.audio, fadeInterval: null };
@@ -525,55 +574,14 @@
     `;
 
     // --- UNIFIED MATERIAL ENGINE ---
-    const atlasLogic = `
-      vec2 getGrid(float col, float row, vec2 localUv) { return vec2((col + localUv.x) / 5.0, (2.0 - row + localUv.y) / 3.0); }
-      vec2 rotateUV(vec2 uv, float angleDeg) {
-        float a = radians(angleDeg); float s = sin(a), c = cos(a);
-        vec2 p = uv - 0.5; return vec2(p.x * c - p.y * s, p.x * s + p.y * c) + 0.5;
-      }
-      vec4 sampleAtlas(sampler2D tex, int face, vec2 local) {
-        if (face == 4) return texture2D(tex, getGrid(1.0, 1.0, local));
-        if (face == 0) return texture2D(tex, getGrid(2.0, 1.0, local));
-        if (face == 5) return texture2D(tex, getGrid(3.0, 1.0, local));
-        
-        if (face == 1) {
-          vec4 c4 = texture2D(tex, getGrid(4.0, 1.0, local));
-          vec4 c0 = texture2D(tex, getGrid(0.0, 1.0, local));
-          return mix(c4, c0, smoothstep(0.25, 0.75, local.x));
-        }
-
-        float d1 = local.x - local.y; 
-        float d2 = (1.0 - local.x) - local.y;
-        float t1 = smoothstep(-0.1, 0.1, d1); 
-        float t2 = smoothstep(-0.1, 0.1, d2);
-        
-        float wBottom = t1 * t2;
-        float wTop    = (1.0 - t1) * (1.0 - t2);
-        float wLeft   = (1.0 - t1) * t2;
-        float wRight  = t1 * (1.0 - t2);
-
-        if (face == 2) {
-          vec4 cFront = texture2D(tex, getGrid(1.0, 0.0, local));
-          vec4 cBack  = texture2D(tex, getGrid(3.0, 0.0, rotateUV(local, 180.0)));
-          vec4 cLeft  = texture2D(tex, getGrid(0.0, 0.0, rotateUV(local, 90.0)));
-          vec4 cRight = texture2D(tex, getGrid(2.0, 0.0, rotateUV(local, -90.0)));
-          return cFront * wBottom + cBack * wTop + cLeft * wLeft + cRight * wRight;
-        }
-        
-        if (face == 3) {
-          vec4 cFront = texture2D(tex, getGrid(1.0, 2.0, local));
-          vec4 cBack  = texture2D(tex, getGrid(3.0, 2.0, rotateUV(local, 180.0)));
-          vec4 cLeft  = texture2D(tex, getGrid(0.0, 2.0, rotateUV(local, -90.0))); 
-          vec4 cRight = texture2D(tex, getGrid(2.0, 2.0, rotateUV(local, 90.0)));
-          return cFront * wTop + cBack * wBottom + cLeft * wLeft + cRight * wRight;
-        }
-        return vec4(0.0);
-      }
-    `;
+    // Atlas sampling GLSL lives in atlas-layout.js, shared with the stitcher.
 
     // seamFill=true adds a tBgColor sampler so torn/discarded fg pixels fall back
     // to the bg colour instead of showing black void.
-    const createMaterials = (colorMode, depthMode, seamFill = false) => {
+    const createMaterials = (colorMode, depthMode, seamFill = false, layoutId = '5x3') => {
+        const usesAtlas = colorMode === 'atlas' || depthMode === 'atlas';
+        const atlasLogic = usesAtlas ? sampleAtlasGlsl(layoutId) : '';
+        const gutterUniform = (usesAtlas && layoutUsesGutter(layoutId)) ? { uGutterFrac: { value: 0.0 } } : {};
         const mats = [];
         for (let i = 0; i < 6; i++) {
           const colorSample     = colorMode === 'atlas' ? `sampleAtlas(tColor, uFace, vUv)` : `texture2D(tColor, vUv)`;
@@ -590,6 +598,7 @@
               uFace: { value: i },
               uIsForeground: { value: 0 },
               uTearThreshold: { value: 0.0 },
+              ...gutterUniform,
               ...extraUniforms
             },
             transparent: true, 
@@ -599,7 +608,7 @@
               uniform int uFace;
               varying vec2 vUv;
               ${gnomonicUvGlsl}
-              ${colorMode === 'atlas' || depthMode === 'atlas' ? atlasLogic : ''}
+              ${atlasLogic}
               void main() {
                 vec3 dir = normalize(position);
                 vec2 rawUv = gnomonicUV(dir, uFace);
@@ -617,7 +626,7 @@
               uniform float uTearThreshold;
               ${seamFill ? 'uniform sampler2D tBgColor;' : ''}
               varying vec2 vUv;
-              ${colorMode === 'atlas' || depthMode === 'atlas' ? atlasLogic : ''}
+              ${atlasLogic}
               void main() {
                 float texDepth = clamp(${fragDepthSample}.r, 0.0, 1.0);
                 float alpha = 1.0;
@@ -672,18 +681,53 @@
         return mats;
     };
 
-    const matSets = {
-        standard:      createMaterials('standard', 'standard'),
-        atlasStandard: createMaterials('atlas', 'standard'), 
-        atlasFg:       createMaterials('atlas', 'atlas', true),  // seamFill enabled
-        atlasBg:       createMaterials('atlas', 'atlas')
+    // Atlas material sets depend on the layout of the atlas being shown, and an
+    // atlas layout is only known once an image has loaded. Build them on first
+    // use for a given layout rather than compiling every combination up front.
+    const MAT_KINDS = {
+        standard:      ['standard', 'standard', false],
+        atlasStandard: ['atlas',    'standard', false],
+        atlasFg:       ['atlas',    'atlas',    true],   // seamFill enabled
+        atlasBg:       ['atlas',    'atlas',    false],
     };
+    const matSetCache = new Map();
 
-    const bgCubeMesh = new THREE.Mesh(bgGeometry, matSets.atlasBg);
-    bgCubeMesh.renderOrder = 0; 
+    function getMatSet(kind, layoutId = '5x3') {
+        const key = kind === 'standard' ? kind : `${kind}|${layoutId}`;
+        let set = matSetCache.get(key);
+        if (!set) {
+            const [colorMode, depthMode, seamFill] = MAT_KINDS[kind];
+            set = createMaterials(colorMode, depthMode, seamFill, layoutId);
+            set.forEach(m => { m.userData.isBg = kind === 'atlasBg'; });
+            matSetCache.set(key, set);
+        }
+        return set;
+    }
+
+    const eachMaterial = (fn) => { for (const set of matSetCache.values()) set.forEach(fn); };
+
+    // The bg sphere displaces at half the fg rate so it stays behind the fg.
+    function setDisplacement(val) {
+        const fgScale = val * 0.95;
+        eachMaterial(m => {
+            m.uniforms.uDisplacementScale.value = m.userData.isBg ? fgScale * 0.5 : fgScale;
+        });
+    }
+
+    // Atlases written in a gutter layout reserve a border of GUTTER_PX per cell;
+    // the shader insets its UVs by the matching fraction.
+    function setGutterFrac(mats, atlasWidth, layoutId) {
+        const l = LAYOUTS[layoutId];
+        if (!l || !l.gutter || !atlasWidth) return;
+        const frac = GUTTER_PX / (atlasWidth / l.cols);
+        mats.forEach(m => { if (m.uniforms.uGutterFrac) m.uniforms.uGutterFrac.value = frac; });
+    }
+
+    const bgCubeMesh = new THREE.Mesh(bgGeometry, getMatSet('atlasBg'));
+    bgCubeMesh.renderOrder = 0;
     scene.add(bgCubeMesh);
 
-    const fgCubeMesh = new THREE.Mesh(geometry, matSets.standard);
+    const fgCubeMesh = new THREE.Mesh(geometry, getMatSet('standard'));
     fgCubeMesh.renderOrder = 1;
     scene.add(fgCubeMesh);
 
@@ -730,20 +774,12 @@
     const tearControls = document.getElementById('tear-controls');
     
     document.getElementById('displacement-slider').addEventListener('input', (e) => {
-      const val = parseFloat(e.target.value) / 100.0;
-      const fgScale = val * 0.95;
-      const bgScale = val * 0.95 * 0.5; // BG displaces at half the fg rate
-      ['standard', 'atlasStandard', 'atlasFg'].forEach(k => {
-        matSets[k].forEach(m => m.uniforms.uDisplacementScale.value = fgScale);
-      });
-      matSets.atlasBg.forEach(m => m.uniforms.uDisplacementScale.value = bgScale);
+      setDisplacement(parseFloat(e.target.value) / 100.0);
     });
-    
+
     document.getElementById('tear-slider').addEventListener('input', (e) => {
         const val = parseFloat(e.target.value) / 100.0;
-        Object.values(matSets).forEach(mats => {
-            mats.forEach(m => m.uniforms.uTearThreshold.value = val);
-        });
+        eachMaterial(m => { m.uniforms.uTearThreshold.value = val; });
     });
 
     const videoTexture = new THREE.VideoTexture(sourceVideo);
@@ -971,12 +1007,10 @@
 
     function safeDisposeTextures() {
         const toDispose = new Set();
-        Object.values(matSets).forEach(mats => {
-            mats.forEach(mat => {
-                const c = mat.uniforms.tColor.value; const d = mat.uniforms.tDepth.value;
-                if (c && c !== videoTexture && c !== defaultCustomTex) toDispose.add(c);
-                if (d && d !== dummyDepthTex) toDispose.add(d);
-            });
+        eachMaterial(mat => {
+            const c = mat.uniforms.tColor.value; const d = mat.uniforms.tDepth.value;
+            if (c && c !== videoTexture && c !== defaultCustomTex) toDispose.add(c);
+            if (d && d !== dummyDepthTex) toDispose.add(d);
         });
         return toDispose;
     }
@@ -1059,9 +1093,10 @@
     const loadErrorEl = document.getElementById('load-error');
     let pendingRetry = null;
 
-    function showLoadError(locationName, retryFn) {
-      document.getElementById('load-error-msg').textContent =
-        `Couldn't load ${locationName}. Check your connection and try again.`;
+    function showLoadError(locationName, retryFn, detail) {
+      document.getElementById('load-error-msg').textContent = detail
+        ? `${locationName}: ${detail}`
+        : `Couldn't load ${locationName}. Check your connection and try again.`;
       pendingRetry = retryFn;
       loadErrorEl.classList.add('active');
     }
@@ -1122,7 +1157,8 @@
             
             const currentSliderVal = hasActiveDepth ? (parseFloat(document.getElementById('displacement-slider').value) / 100.0) : 0.0;
             
-            fgCubeMesh.material = hasActiveDepth ? matSets.atlasStandard : matSets.atlasFg; 
+            // Video atlases are 5x3 by definition of the version's type.
+            fgCubeMesh.material = getMatSet(hasActiveDepth ? 'atlasStandard' : 'atlasFg', '5x3');
             bgCubeMesh.visible = false;
             
             fgCubeMesh.material.forEach((mat, i) => {
@@ -1161,11 +1197,26 @@
             let fgD = loaded[1];
             const bgC = processAtlasTex(loaded[2], true);
             let bgD = loaded[3];
-            
+
             fgD = prepareDepthTex(fgD);
             bgD = prepareDepthTex(bgD);
 
             if (loadId !== currentLoadId) return;
+
+            // Which atlas layout is this? Read it off the aspect ratio of the
+            // first real image we have; a mis-shaped upload used to render as
+            // garbage with no explanation.
+            const shapeSource = [fgC, bgC, fgD, bgD]
+              .find(t => t !== defaultCustomTex && t !== dummyDepthTex && t.image);
+            const atlasW = shapeSource ? shapeSource.image.width : 0;
+            const atlasH = shapeSource ? shapeSource.image.height : 0;
+            const detected = shapeSource ? detectLayout(atlasW, atlasH) : LAYOUTS['5x3'];
+            if (!detected) {
+              throw new Error(
+                `Atlas is ${atlasW}x${atlasH} (${(atlasW / atlasH).toFixed(2)}:1). ` +
+                `Expected 5:3 or 3:2 — stitch it with the face stitcher first.`);
+            }
+            const layoutId = detected.id;
 
             hasActiveDepth = !!customMaps.fgDepth || !!customMaps.bgDepth;
             depthControlsContainer.style.display = hasActiveDepth ? 'flex' : 'none';
@@ -1176,9 +1227,11 @@
             const fgScale = currentSliderVal * 0.95;
             const bgScale = currentSliderVal * 0.95 * 0.5;
             
-            fgCubeMesh.material = matSets.atlasFg;
-            bgCubeMesh.material = matSets.atlasBg;
+            fgCubeMesh.material = getMatSet('atlasFg', layoutId);
+            bgCubeMesh.material = getMatSet('atlasBg', layoutId);
             bgCubeMesh.visible = isDualLayer;
+            setGutterFrac(fgCubeMesh.material, atlasW, layoutId);
+            setGutterFrac(bgCubeMesh.material, atlasW, layoutId);
             
             fgCubeMesh.material.forEach((mat) => {
               mat.uniforms.tColor.value = fgC;
@@ -1231,7 +1284,7 @@
             hasActiveDepth = currentLocation.hasDepth;
             const currentSliderVal = hasActiveDepth ? (parseFloat(document.getElementById('displacement-slider').value) / 100.0) : 0.0;
             
-            fgCubeMesh.material = matSets.standard;
+            fgCubeMesh.material = getMatSet('standard');
             bgCubeMesh.visible = false;
             
             fgCubeMesh.material.forEach((mat, i) => {
@@ -1264,7 +1317,9 @@
 
       } catch (err) {
           console.error("Failed to load panorama:", err);
-          showLoadError(currentLocation.name, () => loadPanorama(mode));
+          // Our own validation errors carry a message worth showing verbatim.
+          showLoadError(currentLocation.name, () => loadPanorama(mode),
+                        err instanceof Error && err.message ? err.message : null);
           return;
       } finally {
           // Every exit path clears the spinner. isTransitioning is only left set
@@ -1426,7 +1481,15 @@
     // land inside the first rendered frame.
     renderer.compile(scene, camera);
     renderer.compile(transitionScene, transitionCamera);
-    loadPanorama('block'); render();
+    render();
+
+    // Arriving from the stitcher (or with #custom) opens straight into the
+    // custom slot, with any handed-off atlases already filled in.
+    (async () => {
+      const handedOff = await takeHandoffAtlases();
+      if (handedOff || location.hash === '#custom') forceCustomSelection();
+      loadPanorama('block');
+    })();
 
   </script>
 </body>

--- a/cube/stitcher.html
+++ b/cube/stitcher.html
@@ -118,8 +118,8 @@
 <div class="controls">
   <div class="ctrl-row">
     <label class="ctrl-lbl">Face size</label>
-    <input type="number" id="face-size" value="1024" min="64" max="4096" step="64">
-    <span style="font-size:12px;color:#555">px → output 5× wide, 3× tall</span>
+    <input type="number" id="face-size" value="1024" min="64" max="1024" step="64">
+    <span id="face-size-hint" style="font-size:12px;color:#555">px → output 5× wide, 3× tall</span>
   </div>
   <div class="ctrl-row">
     <label class="ctrl-lbl">Format</label>
@@ -253,6 +253,7 @@ FACES.forEach(face => {
     const img = new Image();
     img.onload = () => {
       faceImages[face] = img;
+      invalidateFace(face);
       updateThumb(face);
       document.getElementById(`prev-${face}`).classList.add('loaded');
       updateStitchBtn();
@@ -280,6 +281,7 @@ document.querySelectorAll('.rot-btn').forEach(btn => {
   addTapHandler(btn, () => {
     const face = btn.dataset.face, rot = parseInt(btn.dataset.rot);
     faceRot[face] = rot;
+    invalidateFace(face);
     document.querySelectorAll(`.rot-btn[data-face="${face}"]`).forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
     updateThumb(face);
@@ -291,6 +293,7 @@ document.querySelectorAll('.flip-btn').forEach(btn => {
     const face = btn.dataset.face, flip = btn.dataset.flip;
     if (flip === 'h') faceFlipH[face] = !faceFlipH[face];
     else              faceFlipV[face] = !faceFlipV[face];
+    invalidateFace(face);
     btn.classList.toggle('active');
     updateThumb(face);
   });
@@ -299,6 +302,7 @@ document.querySelectorAll('.flip-btn').forEach(btn => {
 addTapHandler(document.getElementById('clear-btn'), () => {
   FACES.forEach(face => {
     delete faceImages[face];
+    invalidateFace(face);
     faceRot[face] = 0; faceFlipH[face] = false; faceFlipV[face] = false;
     document.getElementById(`prev-${face}`).classList.remove('loaded');
     const tc = document.getElementById(`thumb-${face}`);
@@ -311,6 +315,28 @@ addTapHandler(document.getElementById('clear-btn'), () => {
   updateStitchBtn(); setStatus('');
 });
 
+// ── Canvas size limits ───────────────────────────────────────────
+// A 5×3 atlas is 15 × faceSize² pixels. iOS Safari caps a canvas at roughly
+// 16.7M pixels (and other browsers have their own ceilings), so the input's
+// old max of 4096 promised a 20480×12288 canvas that cannot exist anywhere.
+const MAX_CANVAS_AREA = 16777216;
+const MAX_CANVAS_DIM  = 16384;
+
+function maxFaceSize() {
+  const byArea = Math.floor(Math.sqrt(MAX_CANVAS_AREA / 15));
+  const byDim  = Math.floor(MAX_CANVAS_DIM / 5);
+  return Math.max(64, Math.floor(Math.min(byArea, byDim) / 64) * 64);
+}
+
+function applyFaceSizeLimit() {
+  const input = document.getElementById('face-size');
+  const cap = maxFaceSize();
+  input.max = cap;
+  if (parseInt(input.value) > cap) input.value = cap;
+  document.getElementById('face-size-hint').textContent =
+    `px → output 5× wide, 3× tall (max ${cap})`;
+}
+
 function updateStitchBtn() {
   const n = FACES.filter(f => faceImages[f]).length;
   document.getElementById('stitch-btn').disabled = n < 6;
@@ -319,56 +345,52 @@ function updateStitchBtn() {
 function setStatus(m) { document.getElementById('status').textContent = m; }
 
 // ── Offscreen transform: rotate+flip via a scratch canvas ────────
-// Returns an ImageBitmap or HTMLCanvasElement with the transform applied.
-// This approach works on iOS Safari/Chrome where ctx.rotate() can
-// produce incorrect results when combined with translate().
+// Returns an HTMLCanvasElement with the transform applied.
+//
+// The atlas repeats the pole faces at several rotations, so the same
+// (face, rotation, flip, size) combination is requested more than once per
+// stitch — 15 cells resolve to at most 8 distinct renders. Cache them.
+const transformCache = new Map();
+
 function transformedFace(face, totalRotCW, flipH, flipV, size) {
-  const src = faceImages[face];
-  const offscreen = document.createElement('canvas');
-  offscreen.width = size; offscreen.height = size;
-  const oc = offscreen.getContext('2d');
-
-  // Step 1: draw source image at full size into scratch
-  const scratch = document.createElement('canvas');
-  scratch.width = size; scratch.height = size;
-  const sc = scratch.getContext('2d');
-  sc.drawImage(src, 0, 0, size, size);
-  const srcData = sc.getImageData(0, 0, size, size).data;
-
-  // Step 2: pixel-remap according to rotation + flip
-  // We compute for each destination pixel (dx,dy) the source pixel (sx,sy).
-  const dstData = oc.createImageData(size, size);
-  const d = dstData.data;
-  const s = srcData;
-  const n = size;
-
-  // Normalise rotation to 0/90/180/270
   const rot = ((totalRotCW % 360) + 360) % 360;
+  const key = `${face}|${rot}|${flipH}|${flipV}|${size}`;
+  const hit = transformCache.get(key);
+  if (hit) return hit;
 
-  for (let dy = 0; dy < n; dy++) {
-    for (let dx = 0; dx < n; dx++) {
-      // Reverse-map destination → source
-      let sx, sy;
-      // Rotation (CW) → inverse mapping (CCW)
-      if      (rot === 0)   { sx = dx;         sy = dy; }
-      else if (rot === 90)  { sx = dy;         sy = n-1-dx; }
-      else if (rot === 180) { sx = n-1-dx;     sy = n-1-dy; }
-      else                  { sx = n-1-dy;     sy = dx; }      // 270
+  const src = faceImages[face];
+  const canvas = document.createElement('canvas');
+  canvas.width = size; canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
 
-      // Apply flips after rotation
-      if (flipH) sx = n-1-sx;
-      if (flipV) sy = n-1-sy;
-
-      const dIdx = (dy * n + dx) * 4;
-      const sIdx = (sy * n + sx) * 4;
-      d[dIdx]   = s[sIdx];
-      d[dIdx+1] = s[sIdx+1];
-      d[dIdx+2] = s[sIdx+2];
-      d[dIdx+3] = s[sIdx+3];
-    }
+  // Compose flip then rotation as a single affine transform. (This used to be
+  // a per-destination-pixel JS loop, which cost size² iterations per cell —
+  // 15.7M at the default face size and far worse above it.)
+  const n = size;
+  ctx.save();
+  switch (rot) {
+    case 90:  ctx.transform(0, 1, -1, 0, n, 0); break;
+    case 180: ctx.transform(-1, 0, 0, -1, n, n); break;
+    case 270: ctx.transform(0, -1, 1, 0, 0, n); break;
+    default:  break;
   }
-  oc.putImageData(dstData, 0, 0);
-  return offscreen;
+  // Flips are applied in destination space, i.e. after the rotation above.
+  if (flipH) ctx.transform(-1, 0, 0, 1, n, 0);
+  if (flipV) ctx.transform(1, 0, 0, -1, 0, n);
+  ctx.drawImage(src, 0, 0, n, n);
+  ctx.restore();
+
+  transformCache.set(key, canvas);
+  return canvas;
+}
+
+// Any change to a face's image or its rotation/flip invalidates its cached renders.
+function invalidateFace(face) {
+  for (const key of transformCache.keys()) {
+    if (key.startsWith(face + '|')) transformCache.delete(key);
+  }
 }
 
 // Update the small thumbnail preview for a face card
@@ -386,8 +408,14 @@ function updateThumb(face) {
 addTapHandler(document.getElementById('stitch-btn'), stitch);
 
 function stitch() {
-  const faceSize = Math.max(64, Math.min(4096, parseInt(document.getElementById('face-size').value) || 1024));
-  setStatus('Rendering…');
+  const requested = parseInt(document.getElementById('face-size').value) || 1024;
+  const faceSize = Math.max(64, Math.min(maxFaceSize(), requested));
+  if (faceSize < requested) {
+    document.getElementById('face-size').value = faceSize;
+    setStatus(`Face size capped at ${faceSize}px — ${requested}px exceeds the browser's canvas limit.`);
+  } else {
+    setStatus('Rendering…');
+  }
 
   // Use setTimeout so the status text repaints before the heavy work
   setTimeout(() => {
@@ -404,9 +432,27 @@ function stitch() {
       ctx.drawImage(rendered, col * faceSize, row * faceSize);
     });
 
+    // An over-limit canvas doesn't throw — it silently stays blank, and the
+    // failure only used to show up as an empty download. Probe a pixel instead.
+    if (!canvasHasContent(ctx, canvas)) {
+      setStatus(`Browser refused a ${canvas.width}×${canvas.height} canvas — lower the face size.`);
+      document.getElementById('output-wrap').style.display = 'none';
+      return;
+    }
+
     document.getElementById('output-wrap').style.display = 'flex';
     setStatus(`Done — ${canvas.width}×${canvas.height} px`);
   }, 20);
+}
+
+function canvasHasContent(ctx, canvas) {
+  try {
+    // Centre of the front face (row 1, col 1), which is always populated.
+    const d = ctx.getImageData(canvas.width * 0.3, canvas.height * 0.5, 1, 1).data;
+    return d[3] !== 0;
+  } catch (e) {
+    return false;
+  }
 }
 
 // ── Download ─────────────────────────────────────────────────────
@@ -432,6 +478,7 @@ document.getElementById('fmt-select').addEventListener('change', e => {
   document.getElementById('quality').disabled = e.target.value === 'image/png';
 });
 
+applyFaceSizeLimit();
 updateStitchBtn();
 </script>
 </body>

--- a/cube/stitcher.html
+++ b/cube/stitcher.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cubemap Face Stitcher → 5×3 Atlas</title>
+  <title>Cubemap Face Stitcher</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -13,27 +13,29 @@
       padding: 24px 16px 60px;
     }
     h1 { font-size: 20px; font-weight: 600; margin-bottom: 4px; }
-    .subtitle { font-size: 13px; color: #888; margin-bottom: 24px; text-align: center; }
+    .subtitle { font-size: 13px; color: #888; margin-bottom: 8px; text-align: center; }
+    .subtitle a { color: #7eb8f7; }
+    .drophint { font-size: 12px; color: #666; margin-bottom: 20px; text-align: center; }
 
-    .atlas-diagram {
-      display: grid; grid-template-columns: repeat(5, 52px); grid-template-rows: repeat(3, 52px);
-      gap: 2px; margin-bottom: 28px;
-    }
+    .atlas-diagram { display: grid; gap: 2px; margin-bottom: 24px; }
     .atlas-cell {
       background: #222; border: 1px solid #333; border-radius: 3px;
+      width: 52px; height: 52px;
       display: flex; flex-direction: column; align-items: center; justify-content: center;
       font-size: 9px; color: #666; line-height: 1.3; text-align: center;
     }
     .atlas-cell span.face { font-size: 10px; font-weight: 700; color: #ccc; }
-    .atlas-cell.top-row  { background: #1a1a26; border-color: #3a3a5a; }
-    .atlas-cell.mid-row  { background: #1a261a; border-color: #3a5a3a; }
-    .atlas-cell.bot-row  { background: #261a1a; border-color: #5a3a3a; }
-    .atlas-cell.dup      { opacity: 0.5; border-style: dashed; }
+    .atlas-cell.wall { background: #1a261a; border-color: #3a5a3a; }
+    .atlas-cell.pole { background: #1a1a26; border-color: #3a3a5a; }
+    .atlas-cell.dup  { opacity: 0.5; border-style: dashed; }
 
     .faces-grid {
       display: grid; grid-template-columns: repeat(3, 1fr);
-      gap: 12px; width: 100%; max-width: 560px; margin-bottom: 28px;
+      gap: 12px; width: 100%; max-width: 560px; margin-bottom: 24px;
+      border-radius: 10px; transition: outline-color 0.15s;
+      outline: 2px dashed transparent; outline-offset: 8px;
     }
+    .faces-grid.dragover { outline-color: #4ade80; }
     .face-card {
       background: #1c1c1c; border: 1px solid #2a2a2a; border-radius: 8px;
       padding: 12px; display: flex; flex-direction: column; align-items: center; gap: 8px;
@@ -50,32 +52,24 @@
       line-height: 1.5; pointer-events: none; }
     .face-preview.loaded canvas { display: block; }
     .face-preview.loaded .placeholder { display: none; }
-    /* Invisible full-area file trigger */
-    .file-trigger {
-      position: absolute; inset: 0; opacity: 0; cursor: pointer; font-size: 0;
-    }
+    .face-preview:focus-within { border-color: #4ade80; border-style: solid; }
+    .file-trigger { position: absolute; inset: 0; opacity: 0; cursor: pointer; font-size: 0; }
 
-    .rot-row { display: flex; gap: 3px; width: 100%; }
-    .rot-btn {
+    .rot-row, .flip-row { display: flex; gap: 3px; width: 100%; }
+    .flip-row { gap: 6px; }
+    .rot-btn, .flip-btn {
       background: #252525; border: 1px solid #383838; color: #999;
       font-size: 12px; border-radius: 4px; padding: 5px 0; cursor: pointer;
       flex: 1; text-align: center; -webkit-tap-highlight-color: transparent;
       touch-action: manipulation;
     }
+    .flip-btn { font-size: 11px; padding: 4px 0; color: #888; }
     .rot-btn.active { background: #2a3a2a; border-color: #4ade80; color: #4ade80; }
-
-    .flip-row { display: flex; gap: 6px; width: 100%; }
-    .flip-btn {
-      background: #252525; border: 1px solid #383838; color: #888;
-      font-size: 11px; border-radius: 4px; padding: 4px 0; cursor: pointer;
-      flex: 1; text-align: center; -webkit-tap-highlight-color: transparent;
-      touch-action: manipulation;
-    }
     .flip-btn.active { background: #2a1a3a; border-color: #c084fc; color: #c084fc; }
 
     .controls {
       width: 100%; max-width: 560px; display: flex; flex-direction: column; gap: 12px;
-      margin-bottom: 28px;
+      margin-bottom: 24px;
     }
     .ctrl-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
     label.ctrl-lbl { font-size: 12px; color: #888; text-transform: uppercase;
@@ -84,7 +78,11 @@
       background: #1c1c1c; border: 1px solid #333; color: #e0e0e0;
       border-radius: 4px; padding: 6px 10px; font-size: 13px; outline: none;
     }
-    input[type=number] { width: 80px; }
+    select:focus-visible, input:focus-visible, button:focus-visible {
+      outline: 2px solid #4ade80; outline-offset: 2px;
+    }
+    input[type=number] { width: 88px; }
+    .hint { font-size: 12px; color: #555; }
 
     .action-row { display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; margin-bottom: 12px; }
     .btn {
@@ -102,35 +100,51 @@
     }
     #output-wrap h2 { font-size: 15px; font-weight: 600; }
     #output-canvas { width: 100%; border-radius: 6px; border: 1px solid #2a2a2a; }
-    .dl-row { display: flex; gap: 10px; }
+    .dl-row { display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; }
 
-    #status { font-size: 12px; color: #888; min-height: 18px; text-align: center; }
+    #status { font-size: 12px; color: #888; min-height: 18px; text-align: center; max-width: 560px; }
   </style>
 </head>
 <body>
 
 <h1>Cubemap Face Stitcher</h1>
-<p class="subtitle">Upload 6 faces → get a 5×3 atlas for the LDI custom upload</p>
+<p class="subtitle">Six faces → an atlas for the <a href="./index.html">viewer's</a> custom LDI upload</p>
+<p class="drophint">Drop six files anywhere on the face grid and they'll be assigned automatically.</p>
 
 <div class="atlas-diagram" id="atlas-diagram"></div>
 <div class="faces-grid" id="faces-grid"></div>
 
 <div class="controls">
   <div class="ctrl-row">
-    <label class="ctrl-lbl">Face size</label>
-    <input type="number" id="face-size" value="1024" min="64" max="1024" step="64">
-    <span id="face-size-hint" style="font-size:12px;color:#555">px → output 5× wide, 3× tall</span>
+    <label class="ctrl-lbl" for="layout-select">Layout</label>
+    <select id="layout-select"></select>
+    <span class="hint" id="layout-hint"></span>
   </div>
   <div class="ctrl-row">
-    <label class="ctrl-lbl">Format</label>
+    <label class="ctrl-lbl" for="slot-select">Slot</label>
+    <select id="slot-select">
+      <option value="fg-color">FG Color</option>
+      <option value="fg-depth">FG Depth</option>
+      <option value="bg-color">BG Color</option>
+      <option value="bg-depth">BG Depth</option>
+    </select>
+    <span class="hint" id="slot-hint"></span>
+  </div>
+  <div class="ctrl-row">
+    <label class="ctrl-lbl" for="face-size">Face size</label>
+    <input type="number" id="face-size" value="1024" min="64" max="1024" step="64">
+    <span class="hint" id="face-size-hint"></span>
+  </div>
+  <div class="ctrl-row">
+    <label class="ctrl-lbl" for="fmt-select">Format</label>
     <select id="fmt-select">
       <option value="image/webp">WEBP</option>
       <option value="image/jpeg">JPEG</option>
       <option value="image/png">PNG (lossless)</option>
     </select>
-    <label class="ctrl-lbl" style="min-width:unset;margin-left:6px">Quality</label>
+    <label class="ctrl-lbl" for="quality" style="min-width:unset;margin-left:6px">Quality</label>
     <input type="number" id="quality" value="92" min="1" max="100">
-    <span style="font-size:12px;color:#555">%</span>
+    <span class="hint">%</span>
   </div>
 </div>
 
@@ -138,193 +152,50 @@
   <button class="btn btn-primary" id="stitch-btn" disabled>Stitch Atlas</button>
   <button class="btn btn-secondary" id="clear-btn">Clear All</button>
 </div>
-<p id="status"></p>
+<p id="status" role="status" aria-live="polite"></p>
 
 <div id="output-wrap">
-  <h2>Output Atlas (5×3)</h2>
+  <h2 id="output-title">Output Atlas</h2>
   <canvas id="output-canvas"></canvas>
   <div class="dl-row">
     <button class="btn btn-primary" id="dl-btn">⬇ Download</button>
+    <button class="btn btn-secondary" id="viewer-btn">Open in viewer →</button>
   </div>
 </div>
 
-<script>
-// ================================================================
-// ATLAS LAYOUT
-// Row 0 = top face, rotated to align each cell's bottom edge with
-//         the top edge of the wall face directly below it.
-// Row 1 = equatorial walls: Left | Front | Right | Back | Left(dup)
-// Row 2 = bottom face, rotated to align each cell's top edge with
-//         the bottom edge of the wall face directly above it.
-//
-// Equatorial strip (viewed inward, CW from left):
-//   Col 0: Left (-X)   Col 1: Front (+Z)   Col 2: Right (+X)
-//   Col 3: Back (-Z)   Col 4: Left dup (seam wrap)
-//
-// Top-face rotations (base, before user override):
-//   Col 0 (above Left):  -90°  → top face's left edge aligns downward
-//   Col 1 (above Front):   0°  → top face's bottom edge aligns downward  
-//   Col 2 (above Right): +90°  → top face's right edge aligns downward
-//   Col 3 (above Back):  180°  → top face's top edge aligns downward
-//   Col 4 (dup col 0):   -90°
-//
-// Bottom-face rotations (mirror of top):
-//   Col 0: +90°  Col 1: 0°  Col 2: -90°  Col 3: 180°  Col 4: +90°
-// ================================================================
+<script type="module">
+import {
+  FACES, FACE_LABELS, FACE_INDEX, INDEX_FACE, LAYOUTS, GUTTER_PX,
+  faceUvToDir, dirToFaceUv,
+} from './atlas-layout.js';
 
-const FACES = ['left','front','right','back','top','bottom'];
-const FACE_LABELS = {
-  left:   'Left (−X)',  front: 'Front (+Z)',
-  right:  'Right (+X)', back:  'Back (−Z)',
-  top:    'Top (+Y)',   bottom:'Bottom (−Y)'
-};
-
-const LAYOUT = [
-  // Row 0 – top face at each horizontal position
-  { face:'top',    rot: -90, note:'Top\n-90°' },
-  { face:'top',    rot:   0, note:'Top\n0°'   },
-  { face:'top',    rot:  90, note:'Top\n+90°' },
-  { face:'top',    rot: 180, note:'Top\n180°' },
-  { face:'top',    rot: -90, note:'Top\ndup'   },
-  // Row 1 – equatorial walls
-  { face:'left',   rot:   0, note:'Left'  },
-  { face:'front',  rot:   0, note:'Front' },
-  { face:'right',  rot:   0, note:'Right' },
-  { face:'back',   rot:   0, note:'Back'  },
-  { face:'left',   rot:   0, note:'L dup' },
-  // Row 2 – bottom face at each horizontal position
-  { face:'bottom', rot:  90, note:'Bot\n+90°' },
-  { face:'bottom', rot:   0, note:'Bot\n0°'   },
-  { face:'bottom', rot: -90, note:'Bot\n-90°' },
-  { face:'bottom', rot: 180, note:'Bot\n180°' },
-  { face:'bottom', rot:  90, note:'Bot\ndup'   },
-];
-
-// Per-face user overrides
+// ── State ────────────────────────────────────────────────────────
 const faceImages = {};
-const faceRot    = {}; // 0 / 90 / 180 / 270
+const faceRot    = {};
 const faceFlipH  = {};
 const faceFlipV  = {};
 FACES.forEach(f => { faceRot[f] = 0; faceFlipH[f] = false; faceFlipV[f] = false; });
 
-// ── Atlas diagram ────────────────────────────────────────────────
-const rowClass = ['top-row','mid-row','bot-row'];
-const diagramEl = document.getElementById('atlas-diagram');
-LAYOUT.forEach((cell, i) => {
-  const row = Math.floor(i / 5), col = i % 5;
-  const el = document.createElement('div');
-  el.className = `atlas-cell ${rowClass[row]}${col === 4 ? ' dup' : ''}`;
-  el.innerHTML = cell.note.split('\n').map((l,j) =>
-    j === 0 ? `<span class="face">${l}</span>` : `<span>${l}</span>`
-  ).join('');
-  el.title = `Row ${row}, Col ${col}: ${cell.face} base rot ${cell.rot}°`;
-  diagramEl.appendChild(el);
-});
+let layout = LAYOUTS['3x2'];
 
-// ── Face upload cards ────────────────────────────────────────────
-const grid = document.getElementById('faces-grid');
-FACES.forEach(face => {
-  const card = document.createElement('div');
-  card.className = 'face-card';
-  card.innerHTML = `
-    <h3>${FACE_LABELS[face]}</h3>
-    <div class="face-preview" id="prev-${face}">
-      <canvas id="thumb-${face}"></canvas>
-      <div class="placeholder">Tap / click<br>to upload</div>
-      <input type="file" accept="image/*" class="file-trigger" id="file-${face}" tabindex="-1">
-    </div>
-    <div class="rot-row">
-      <button class="rot-btn active" data-face="${face}" data-rot="0">0°</button>
-      <button class="rot-btn" data-face="${face}" data-rot="90">90°</button>
-      <button class="rot-btn" data-face="${face}" data-rot="180">180°</button>
-      <button class="rot-btn" data-face="${face}" data-rot="270">270°</button>
-    </div>
-    <div class="flip-row">
-      <button class="flip-btn" data-face="${face}" data-flip="h">⇔ Flip H</button>
-      <button class="flip-btn" data-face="${face}" data-flip="v">⇕ Flip V</button>
-    </div>
-  `;
-  grid.appendChild(card);
+const SLOT_LABELS = {
+  'fg-color': 'FG Color', 'fg-depth': 'FG Depth',
+  'bg-color': 'BG Color', 'bg-depth': 'BG Depth',
+};
+const isDepthSlot = () => document.getElementById('slot-select').value.endsWith('-depth');
 
-  // File input
-  document.getElementById(`file-${face}`).addEventListener('change', e => {
-    const file = e.target.files[0]; if (!file) return;
-    const url = URL.createObjectURL(file);
-    const img = new Image();
-    img.onload = () => {
-      faceImages[face] = img;
-      invalidateFace(face);
-      updateThumb(face);
-      document.getElementById(`prev-${face}`).classList.add('loaded');
-      updateStitchBtn();
-      URL.revokeObjectURL(url);
-    };
-    img.onerror = () => {
-      URL.revokeObjectURL(url);
-      setStatus(`Couldn't read "${file.name}" as an image — try PNG, JPEG or WEBP.`);
-    };
-    img.src = url;
-    e.target.value = '';
-  });
-});
-
-// Rotation buttons – use touchend + click with a guard to avoid double-fire
-function addTapHandler(el, fn) {
-  let touched = false;
-  el.addEventListener('touchend', e => {
-    e.preventDefault(); touched = true; fn(); setTimeout(() => touched = false, 400);
-  });
-  el.addEventListener('click', () => { if (!touched) fn(); });
-}
-
-document.querySelectorAll('.rot-btn').forEach(btn => {
-  addTapHandler(btn, () => {
-    const face = btn.dataset.face, rot = parseInt(btn.dataset.rot);
-    faceRot[face] = rot;
-    invalidateFace(face);
-    document.querySelectorAll(`.rot-btn[data-face="${face}"]`).forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-    updateThumb(face);
-  });
-});
-
-document.querySelectorAll('.flip-btn').forEach(btn => {
-  addTapHandler(btn, () => {
-    const face = btn.dataset.face, flip = btn.dataset.flip;
-    if (flip === 'h') faceFlipH[face] = !faceFlipH[face];
-    else              faceFlipV[face] = !faceFlipV[face];
-    invalidateFace(face);
-    btn.classList.toggle('active');
-    updateThumb(face);
-  });
-});
-
-addTapHandler(document.getElementById('clear-btn'), () => {
-  FACES.forEach(face => {
-    delete faceImages[face];
-    invalidateFace(face);
-    faceRot[face] = 0; faceFlipH[face] = false; faceFlipV[face] = false;
-    document.getElementById(`prev-${face}`).classList.remove('loaded');
-    const tc = document.getElementById(`thumb-${face}`);
-    const tx = tc.getContext('2d'); tx.clearRect(0,0,tc.width,tc.height);
-    document.querySelectorAll(`.rot-btn[data-face="${face}"]`).forEach(b => b.classList.remove('active'));
-    document.querySelector(`.rot-btn[data-face="${face}"][data-rot="0"]`).classList.add('active');
-    document.querySelectorAll(`.flip-btn[data-face="${face}"]`).forEach(b => b.classList.remove('active'));
-  });
-  document.getElementById('output-wrap').style.display = 'none';
-  updateStitchBtn(); setStatus('');
-});
+function setStatus(m) { document.getElementById('status').textContent = m; }
 
 // ── Canvas size limits ───────────────────────────────────────────
-// A 5×3 atlas is 15 × faceSize² pixels. iOS Safari caps a canvas at roughly
-// 16.7M pixels (and other browsers have their own ceilings), so the input's
-// old max of 4096 promised a 20480×12288 canvas that cannot exist anywhere.
+// iOS Safari caps a canvas at roughly 16.7M pixels, and every browser has some
+// ceiling. The old input offered 4096, which at 5×3 promised a 20480×12288
+// canvas that cannot exist anywhere.
 const MAX_CANVAS_AREA = 16777216;
 const MAX_CANVAS_DIM  = 16384;
 
-function maxFaceSize() {
-  const byArea = Math.floor(Math.sqrt(MAX_CANVAS_AREA / 15));
-  const byDim  = Math.floor(MAX_CANVAS_DIM / 5);
+function maxFaceSize(l = layout) {
+  const byArea = Math.floor(Math.sqrt(MAX_CANVAS_AREA / (l.cols * l.rows)));
+  const byDim  = Math.floor(MAX_CANVAS_DIM / l.cols);
   return Math.max(64, Math.floor(Math.min(byArea, byDim) / 64) * 64);
 }
 
@@ -333,23 +204,239 @@ function applyFaceSizeLimit() {
   const cap = maxFaceSize();
   input.max = cap;
   if (parseInt(input.value) > cap) input.value = cap;
+  const size = Math.min(cap, parseInt(input.value) || 1024);
+  const gutterNote = layout.gutter
+    ? `, ${size - 2 * layout.gutter}px of it image` // the rest is gutter
+    : '';
   document.getElementById('face-size-hint').textContent =
-    `px → output 5× wide, 3× tall (max ${cap})`;
+    `px → ${layout.cols * size}×${layout.rows * size} atlas${gutterNote} (max ${cap})`;
 }
+
+// ── Atlas diagram ────────────────────────────────────────────────
+function renderDiagram() {
+  const el = document.getElementById('atlas-diagram');
+  el.style.gridTemplateColumns = `repeat(${layout.cols}, 52px)`;
+  el.style.gridTemplateRows = `repeat(${layout.rows}, 52px)`;
+  el.innerHTML = '';
+  layout.cells.forEach((cell, i) => {
+    const row = Math.floor(i / layout.cols), col = i % layout.cols;
+    const isPole = cell.face === 'top' || cell.face === 'bottom';
+    const isDup = layout.cells.findIndex(c => c.face === cell.face) !== i;
+    const d = document.createElement('div');
+    d.className = `atlas-cell ${isPole ? 'pole' : 'wall'}${isDup ? ' dup' : ''}`;
+    d.innerHTML = cell.note.split('\n').map((l, j) =>
+      j === 0 ? `<span class="face">${l}</span>` : `<span>${l}</span>`).join('');
+    d.title = `Row ${row}, Col ${col}: ${cell.face}, base rotation ${cell.rot}°`;
+    el.appendChild(d);
+  });
+}
+
+// ── Face cards ───────────────────────────────────────────────────
+const grid = document.getElementById('faces-grid');
+FACES.forEach(face => {
+  const card = document.createElement('div');
+  card.className = 'face-card';
+  card.innerHTML = `
+    <h3 id="lbl-${face}">${FACE_LABELS[face]}</h3>
+    <div class="face-preview" id="prev-${face}">
+      <canvas id="thumb-${face}"></canvas>
+      <div class="placeholder">Tap / click<br>to upload</div>
+      <input type="file" accept="image/*" class="file-trigger" id="file-${face}"
+             aria-labelledby="lbl-${face}">
+    </div>
+    <div class="rot-row" role="group" aria-label="${FACE_LABELS[face]} rotation">
+      ${[0, 90, 180, 270].map(r => `
+        <button class="rot-btn${r === 0 ? ' active' : ''}" data-face="${face}" data-rot="${r}"
+                aria-pressed="${r === 0}">${r}°</button>`).join('')}
+    </div>
+    <div class="flip-row">
+      <button class="flip-btn" data-face="${face}" data-flip="h" aria-pressed="false">⇔ Flip H</button>
+      <button class="flip-btn" data-face="${face}" data-flip="v" aria-pressed="false">⇕ Flip V</button>
+    </div>
+  `;
+  grid.appendChild(card);
+
+  document.getElementById(`file-${face}`).addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (file) loadFaceFile(face, file);
+    e.target.value = '';
+  });
+});
+
+// EXIF orientation is honoured here; iOS photos otherwise arrive rotated.
+async function decode(file) {
+  try {
+    return await createImageBitmap(file, { imageOrientation: 'from-image' });
+  } catch (e) {
+    return await new Promise((resolve, reject) => {
+      const url = URL.createObjectURL(file);
+      const img = new Image();
+      img.onload  = () => { URL.revokeObjectURL(url); resolve(img); };
+      img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('decode failed')); };
+      img.src = url;
+    });
+  }
+}
+
+async function loadFaceFile(face, file) {
+  try {
+    const img = await decode(file);
+    faceImages[face] = img;
+    invalidateFace(face);
+    updateThumb(face);
+    document.getElementById(`prev-${face}`).classList.add('loaded');
+    updateStitchBtn();
+    warnAboutInputs();
+  } catch (e) {
+    setStatus(`Couldn't read "${file.name}" as an image — try PNG, JPEG or WEBP.`);
+  }
+}
+
+// Non-square or mismatched faces used to be squashed silently.
+function warnAboutInputs() {
+  const loaded = FACES.filter(f => faceImages[f]);
+  const nonSquare = loaded.filter(f => faceImages[f].width !== faceImages[f].height);
+  const sizes = new Set(loaded.map(f => `${faceImages[f].width}x${faceImages[f].height}`));
+  const notes = [];
+  if (nonSquare.length) notes.push(`${nonSquare.join(', ')} not square — will be squashed to fit`);
+  if (sizes.size > 1) notes.push(`mixed face sizes (${[...sizes].join(', ')})`);
+  if (notes.length) setStatus('Heads up: ' + notes.join('; ') + '.');
+}
+
+// ── Drag & drop with filename inference ──────────────────────────
+// Rules are tried in order; the first that assigns all six wins.
+const WORD_PATTERNS = [
+  { name: 'face names', map: { left: /(^|[^a-z])(left|lf)([^a-z]|$)/i, right: /(^|[^a-z])(right|rt)([^a-z]|$)/i,
+      top: /(^|[^a-z])(top|up)([^a-z]|$)/i, bottom: /(^|[^a-z])(bottom|bot|down|dn)([^a-z]|$)/i,
+      front: /(^|[^a-z])(front|ft)([^a-z]|$)/i, back: /(^|[^a-z])(back|bk)([^a-z]|$)/i } },
+  { name: 'axis codes', map: { right: /(^|[^a-z])(pos)?x([^a-z]|$)/i, left: /(^|[^a-z])n(eg)?x([^a-z]|$)/i,
+      top: /(^|[^a-z])(pos)?y([^a-z]|$)/i, bottom: /(^|[^a-z])n(eg)?y([^a-z]|$)/i,
+      front: /(^|[^a-z])(pos)?z([^a-z]|$)/i, back: /(^|[^a-z])n(eg)?z([^a-z]|$)/i } },
+];
+
+// Every built-in dataset in this repo numbers its faces in the same order —
+// MAWWnodes-8..13, LEIS661..666, ENCHnodes-277..282 — so six files sorted by
+// trailing number assign correctly with no renaming. (Read off getCubemapUrls
+// in index.html.)
+const NUMERIC_ORDER = ['front', 'bottom', 'back', 'right', 'left', 'top'];
+
+function inferAssignment(files) {
+  const names = files.map(f => f.name.replace(/\.[^.]+$/, ''));
+
+  for (const rule of WORD_PATTERNS) {
+    const picked = {};
+    const used = new Set();
+    for (const [face, re] of Object.entries(rule.map)) {
+      const idx = names.findIndex((n, i) => !used.has(i) && re.test(n));
+      if (idx === -1) break;
+      picked[face] = files[idx]; used.add(idx);
+    }
+    if (Object.keys(picked).length === 6) return { assignment: picked, rule: rule.name };
+  }
+
+  // Trailing index 0..5.
+  const byIndex = {};
+  let indexed = true;
+  for (let i = 0; i < files.length; i++) {
+    const m = names[i].match(/[_-]([0-5])$/);
+    if (!m) { indexed = false; break; }
+    byIndex[NUMERIC_ORDER[+m[1]]] = files[i];
+  }
+  if (indexed && Object.keys(byIndex).length === 6) {
+    return { assignment: byIndex, rule: 'trailing 0–5 index' };
+  }
+
+  // Numeric-sequence fallback.
+  const nums = names.map(n => { const m = n.match(/(\d+)(?!.*\d)/); return m ? +m[1] : null; });
+  if (nums.every(n => n !== null) && new Set(nums).size === 6) {
+    const order = files.map((f, i) => ({ f, n: nums[i] })).sort((a, b) => a.n - b.n);
+    const picked = {};
+    order.forEach((o, i) => { picked[NUMERIC_ORDER[i]] = o.f; });
+    return { assignment: picked, rule: 'numeric sequence' };
+  }
+  return null;
+}
+
+grid.addEventListener('dragover', e => { e.preventDefault(); grid.classList.add('dragover'); });
+grid.addEventListener('dragleave', e => { if (e.target === grid) grid.classList.remove('dragover'); });
+grid.addEventListener('drop', async e => {
+  e.preventDefault();
+  grid.classList.remove('dragover');
+  const files = [...e.dataTransfer.files].filter(f => f.type.startsWith('image/'));
+  if (!files.length) { setStatus('No image files in that drop.'); return; }
+
+  if (files.length === 1) {
+    setStatus('Dropped one file — drop six at once to auto-assign, or click a face to place it.');
+    return;
+  }
+  if (files.length !== 6) { setStatus(`Dropped ${files.length} files — expected 6.`); return; }
+
+  const result = inferAssignment(files);
+  if (!result) {
+    setStatus("Couldn't work out which file is which face — click each face to place them.");
+    return;
+  }
+  for (const [face, file] of Object.entries(result.assignment)) await loadFaceFile(face, file);
+  setStatus(`Assigned 6 faces by ${result.rule}. Check the previews and reassign any that look wrong.`);
+});
+
+// ── Rotation / flip ──────────────────────────────────────────────
+grid.addEventListener('click', e => {
+  const rot = e.target.closest('.rot-btn');
+  if (rot) {
+    const face = rot.dataset.face;
+    faceRot[face] = parseInt(rot.dataset.rot);
+    invalidateFace(face);
+    document.querySelectorAll(`.rot-btn[data-face="${face}"]`).forEach(b => {
+      b.classList.remove('active'); b.setAttribute('aria-pressed', 'false');
+    });
+    rot.classList.add('active'); rot.setAttribute('aria-pressed', 'true');
+    updateThumb(face);
+    return;
+  }
+  const flip = e.target.closest('.flip-btn');
+  if (flip) {
+    const face = flip.dataset.face;
+    if (flip.dataset.flip === 'h') faceFlipH[face] = !faceFlipH[face];
+    else                           faceFlipV[face] = !faceFlipV[face];
+    invalidateFace(face);
+    flip.classList.toggle('active');
+    flip.setAttribute('aria-pressed', String(flip.classList.contains('active')));
+    updateThumb(face);
+  }
+});
+
+document.getElementById('clear-btn').addEventListener('click', () => {
+  FACES.forEach(face => {
+    delete faceImages[face];
+    invalidateFace(face);
+    faceRot[face] = 0; faceFlipH[face] = false; faceFlipV[face] = false;
+    document.getElementById(`prev-${face}`).classList.remove('loaded');
+    const tc = document.getElementById(`thumb-${face}`);
+    tc.getContext('2d').clearRect(0, 0, tc.width, tc.height);
+    document.querySelectorAll(`.rot-btn[data-face="${face}"]`).forEach(b => {
+      b.classList.toggle('active', b.dataset.rot === '0');
+      b.setAttribute('aria-pressed', String(b.dataset.rot === '0'));
+    });
+    document.querySelectorAll(`.flip-btn[data-face="${face}"]`).forEach(b => {
+      b.classList.remove('active'); b.setAttribute('aria-pressed', 'false');
+    });
+  });
+  document.getElementById('output-wrap').style.display = 'none';
+  updateStitchBtn(); setStatus('');
+});
 
 function updateStitchBtn() {
   const n = FACES.filter(f => faceImages[f]).length;
   document.getElementById('stitch-btn').disabled = n < 6;
-  setStatus(n < 6 ? `${n}/6 faces loaded` : 'All 6 faces ready — tap Stitch!');
+  if (!document.getElementById('status').textContent.startsWith('Heads up')) {
+    setStatus(n < 6 ? `${n}/6 faces loaded` : 'All 6 faces ready — tap Stitch!');
+  }
 }
-function setStatus(m) { document.getElementById('status').textContent = m; }
 
-// ── Offscreen transform: rotate+flip via a scratch canvas ────────
-// Returns an HTMLCanvasElement with the transform applied.
-//
-// The atlas repeats the pole faces at several rotations, so the same
-// (face, rotation, flip, size) combination is requested more than once per
-// stitch — 15 cells resolve to at most 8 distinct renders. Cache them.
+// ── Face transform, memoized ─────────────────────────────────────
+// The 5×3 atlas repeats the pole faces at several rotations, so the same
+// (face, rotation, flip, size) is requested more than once per stitch.
 const transformCache = new Map();
 
 function transformedFace(face, totalRotCW, flipH, flipV, size) {
@@ -361,22 +448,19 @@ function transformedFace(face, totalRotCW, flipH, flipV, size) {
   const src = faceImages[face];
   const canvas = document.createElement('canvas');
   canvas.width = size; canvas.height = size;
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
   ctx.imageSmoothingEnabled = true;
   ctx.imageSmoothingQuality = 'high';
 
-  // Compose flip then rotation as a single affine transform. (This used to be
-  // a per-destination-pixel JS loop, which cost size² iterations per cell —
-  // 15.7M at the default face size and far worse above it.)
+  // Flip then rotation, composed as one affine transform. (This used to be a
+  // per-destination-pixel JS loop costing size² iterations per cell.)
   const n = size;
   ctx.save();
   switch (rot) {
     case 90:  ctx.transform(0, 1, -1, 0, n, 0); break;
     case 180: ctx.transform(-1, 0, 0, -1, n, n); break;
     case 270: ctx.transform(0, -1, 1, 0, 0, n); break;
-    default:  break;
   }
-  // Flips are applied in destination space, i.e. after the rotation above.
   if (flipH) ctx.transform(-1, 0, 0, 1, n, 0);
   if (flipV) ctx.transform(1, 0, 0, -1, 0, n);
   ctx.drawImage(src, 0, 0, n, n);
@@ -386,26 +470,70 @@ function transformedFace(face, totalRotCW, flipH, flipV, size) {
   return canvas;
 }
 
-// Any change to a face's image or its rotation/flip invalidates its cached renders.
 function invalidateFace(face) {
   for (const key of transformCache.keys()) {
     if (key.startsWith(face + '|')) transformCache.delete(key);
   }
 }
 
-// Update the small thumbnail preview for a face card
 function updateThumb(face) {
-  const img = faceImages[face]; if (!img) return;
+  if (!faceImages[face]) return;
   const SIZE = 128;
   const tc = document.getElementById(`thumb-${face}`);
   tc.width = SIZE; tc.height = SIZE;
-  const totalRot = ((faceRot[face] % 360) + 360) % 360;
-  const transformed = transformedFace(face, totalRot, faceFlipH[face], faceFlipV[face], SIZE);
-  tc.getContext('2d').drawImage(transformed, 0, 0);
+  tc.getContext('2d').drawImage(
+    transformedFace(face, faceRot[face], faceFlipH[face], faceFlipV[face], SIZE), 0, 0);
+}
+
+// ── Gutter ───────────────────────────────────────────────────────
+// The 3×2 layout drops the pole duplication that gave the 5×3 atlas correct
+// bilinear neighbours at the pole edges. A gutter restores it: each cell
+// reserves a GUTTER_PX border filled by projecting back out to the cube and
+// resampling whichever face that direction actually lands on. One piece of
+// maths covers every edge and corner, with no adjacency table to get wrong.
+function buildGutter(ctx, cellX, cellY, face, S, G, contents) {
+  const C = S - 2 * G;
+  const faceIndex = FACE_INDEX[face];
+
+  const paint = (x0, y0, w, h) => {
+    if (w <= 0 || h <= 0) return;
+    const out = ctx.createImageData(w, h);
+    const d = out.data;
+    for (let dy = 0; dy < h; dy++) {
+      for (let dx = 0; dx < w; dx++) {
+        // Cell-local pixel -> face UV (v runs bottom-up, matching the texture).
+        const px = x0 + dx, py = y0 + dy;
+        const u = (px + 0.5 - G) / C;
+        const v = 1 - (py + 0.5 - G) / C;
+
+        const [X, Y, Z] = faceUvToDir(faceIndex, u, v);
+        const hitFace = dirToFaceUv(X, Y, Z);
+        const srcName = INDEX_FACE[hitFace.faceIndex];
+        const src = contents[srcName];
+
+        const i = (dy * w + dx) * 4;
+        if (!src) { d[i + 3] = 255; continue; }
+
+        const sx = Math.min(C - 1, Math.max(0, Math.round(hitFace.u * C - 0.5)));
+        const sy = Math.min(C - 1, Math.max(0, Math.round((1 - hitFace.v) * C - 0.5)));
+        const j = (sy * C + sx) * 4;
+        d[i]     = src.data[j];
+        d[i + 1] = src.data[j + 1];
+        d[i + 2] = src.data[j + 2];
+        d[i + 3] = src.data[j + 3];
+      }
+    }
+    ctx.putImageData(out, cellX + x0, cellY + y0);
+  };
+
+  paint(0, 0, S, G);                    // top band
+  paint(0, S - G, S, G);                // bottom band
+  paint(0, G, G, S - 2 * G);            // left band
+  paint(S - G, G, G, S - 2 * G);        // right band
 }
 
 // ── Stitch ───────────────────────────────────────────────────────
-addTapHandler(document.getElementById('stitch-btn'), stitch);
+document.getElementById('stitch-btn').addEventListener('click', stitch);
 
 function stitch() {
   const requested = parseInt(document.getElementById('face-size').value) || 1024;
@@ -417,29 +545,47 @@ function stitch() {
     setStatus('Rendering…');
   }
 
-  // Use setTimeout so the status text repaints before the heavy work
+  // Let the status repaint before the heavy work.
   setTimeout(() => {
-    const canvas = document.getElementById('output-canvas');
-    canvas.width  = faceSize * 5;
-    canvas.height = faceSize * 3;
-    const ctx = canvas.getContext('2d');
+    const G = layout.gutter;
+    const C = faceSize - 2 * G;
+    if (C < 16) { setStatus(`Face size too small for a ${G}px gutter.`); return; }
 
-    LAYOUT.forEach((cell, idx) => {
-      const col = idx % 5, row = Math.floor(idx / 5);
+    const canvas = document.getElementById('output-canvas');
+    canvas.width  = faceSize * layout.cols;
+    canvas.height = faceSize * layout.rows;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+
+    // Content images at the inner size, needed both for drawing and (for the
+    // gutter) for cross-face sampling.
+    const contents = {};
+    if (G > 0) {
+      for (const f of FACES) {
+        const c = transformedFace(f, faceRot[f], faceFlipH[f], faceFlipV[f], C);
+        contents[f] = c.getContext('2d', { willReadFrequently: true }).getImageData(0, 0, C, C);
+      }
+    }
+
+    layout.cells.forEach((cell, idx) => {
+      const col = idx % layout.cols, row = Math.floor(idx / layout.cols);
       if (!faceImages[cell.face]) return;
-      const totalRot = ((cell.rot + faceRot[cell.face]) % 360 + 360) % 360;
-      const rendered = transformedFace(cell.face, totalRot, faceFlipH[cell.face], faceFlipV[cell.face], faceSize);
-      ctx.drawImage(rendered, col * faceSize, row * faceSize);
+      const cellX = col * faceSize, cellY = row * faceSize;
+      const totalRot = cell.rot + faceRot[cell.face];
+      const rendered = transformedFace(cell.face, totalRot, faceFlipH[cell.face], faceFlipV[cell.face], C);
+      ctx.drawImage(rendered, cellX + G, cellY + G);
+      if (G > 0) buildGutter(ctx, cellX, cellY, cell.face, faceSize, G, contents);
     });
 
-    // An over-limit canvas doesn't throw — it silently stays blank, and the
-    // failure only used to show up as an empty download. Probe a pixel instead.
+    // An over-limit canvas doesn't throw, it silently stays blank — the failure
+    // used to surface only as an empty download.
     if (!canvasHasContent(ctx, canvas)) {
       setStatus(`Browser refused a ${canvas.width}×${canvas.height} canvas — lower the face size.`);
       document.getElementById('output-wrap').style.display = 'none';
       return;
     }
 
+    document.getElementById('output-title').textContent =
+      `Output Atlas (${layout.cols}×${layout.rows}) — ${SLOT_LABELS[document.getElementById('slot-select').value]}`;
     document.getElementById('output-wrap').style.display = 'flex';
     setStatus(`Done — ${canvas.width}×${canvas.height} px`);
   }, 20);
@@ -447,38 +593,111 @@ function stitch() {
 
 function canvasHasContent(ctx, canvas) {
   try {
-    // Centre of the front face (row 1, col 1), which is always populated.
-    const d = ctx.getImageData(canvas.width * 0.3, canvas.height * 0.5, 1, 1).data;
+    const d = ctx.getImageData(Math.floor(canvas.width * 0.5), Math.floor(canvas.height * 0.25), 1, 1).data;
     return d[3] !== 0;
   } catch (e) {
     return false;
   }
 }
 
-// ── Download ─────────────────────────────────────────────────────
-addTapHandler(document.getElementById('dl-btn'), () => {
+// ── Output ───────────────────────────────────────────────────────
+function encodeAtlas() {
   const canvas = document.getElementById('output-canvas');
-  if (!canvas.width) return;
-  const fmt = document.getElementById('fmt-select').value;
+  if (!canvas.width) return null;
+  // Depth maps are data, not pictures: lossy encoding bands and rings them.
+  const fmt = isDepthSlot() ? 'image/png' : document.getElementById('fmt-select').value;
   const q = Math.max(0.01, Math.min(1, parseInt(document.getElementById('quality').value) / 100));
   const ext = fmt === 'image/png' ? 'png' : fmt === 'image/webp' ? 'webp' : 'jpg';
+  const slot = document.getElementById('slot-select').value;
+  return new Promise(resolve => {
+    canvas.toBlob(blob => resolve(blob ? { blob, ext, name: `cubemap_${layout.id}_${slot}.${ext}` } : null), fmt, q);
+  });
+}
+
+document.getElementById('dl-btn').addEventListener('click', async () => {
   setStatus('Encoding…');
-  canvas.toBlob(blob => {
-    if (!blob) { setStatus('Encoding failed — try PNG or smaller face size'); return; }
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = `cubemap_atlas.${ext}`;
-    document.body.appendChild(a); a.click(); document.body.removeChild(a);
-    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
-    setStatus(`Downloaded cubemap_atlas.${ext} (${(blob.size/1024).toFixed(0)} KB)`);
-  }, fmt, q);
+  const out = await encodeAtlas();
+  if (!out) { setStatus('Encoding failed — try PNG or a smaller face size.'); return; }
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(out.blob);
+  a.download = out.name;
+  document.body.appendChild(a); a.click(); document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+  setStatus(`Downloaded ${out.name} (${(out.blob.size / 1024).toFixed(0)} KB)`);
 });
+
+// ── Handoff to the viewer ────────────────────────────────────────
+// Atlases run to several MB and there can be four of them, so sessionStorage
+// (~5MB, strings only) is not an option. IndexedDB takes the blobs directly.
+const DB_NAME = 'cubemap-handoff', STORE = 'atlases';
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function stashAtlas(slot, blob) {
+  const db = await openDb();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).put(blob, slot);
+    tx.oncomplete = resolve;
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+}
+
+document.getElementById('viewer-btn').addEventListener('click', async () => {
+  setStatus('Encoding…');
+  const out = await encodeAtlas();
+  if (!out) { setStatus('Encoding failed — try PNG or a smaller face size.'); return; }
+  const slot = document.getElementById('slot-select').value;
+  try {
+    await stashAtlas(slot, out.blob);
+    location.href = './index.html#custom';
+  } catch (e) {
+    setStatus('Could not hand off to the viewer — download the file and upload it instead.');
+  }
+});
+
+// ── Wiring ───────────────────────────────────────────────────────
+const layoutSelect = document.getElementById('layout-select');
+Object.values(LAYOUTS).forEach(l => {
+  const o = document.createElement('option');
+  o.value = l.id; o.textContent = l.label; layoutSelect.appendChild(o);
+});
+layoutSelect.value = layout.id;
+
+function applyLayout() {
+  layout = LAYOUTS[layoutSelect.value];
+  document.getElementById('layout-hint').textContent = layout.note;
+  renderDiagram();
+  applyFaceSizeLimit();
+  document.getElementById('output-wrap').style.display = 'none';
+}
+layoutSelect.addEventListener('change', applyLayout);
+document.getElementById('face-size').addEventListener('input', applyFaceSizeLimit);
+
+function applySlot() {
+  const depth = isDepthSlot();
+  document.getElementById('fmt-select').disabled = depth;
+  document.getElementById('quality').disabled = depth || document.getElementById('fmt-select').value === 'image/png';
+  document.getElementById('slot-hint').textContent = depth
+    ? 'Depth maps export as lossless PNG — JPEG/WEBP band the gradients.'
+    : 'Names the download and the viewer slot this atlas fills.';
+}
+document.getElementById('slot-select').addEventListener('change', applySlot);
 
 document.getElementById('fmt-select').addEventListener('change', e => {
-  document.getElementById('quality').disabled = e.target.value === 'image/png';
+  document.getElementById('quality').disabled = isDepthSlot() || e.target.value === 'image/png';
 });
 
-applyFaceSizeLimit();
+applyLayout();
+applySlot();
 updateStitchBtn();
 </script>
 </body>

--- a/cube/stitcher.html
+++ b/cube/stitcher.html
@@ -258,6 +258,10 @@ FACES.forEach(face => {
       updateStitchBtn();
       URL.revokeObjectURL(url);
     };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      setStatus(`Couldn't read "${file.name}" as an image — try PNG, JPEG or WEBP.`);
+    };
     img.src = url;
     e.target.value = '';
   });

--- a/index.html
+++ b/index.html
@@ -54,8 +54,12 @@
   <p class="subtitle">A collection of web-based tools and interactive viewers.</p>
   <ul>
     <li>
-      <a href="https://e-z-g.github.io/cubemap_viewer/">Cubemap VR Viewer</a>
+      <a href="https://e-z-g.github.io/cube/">Cubemap VR Viewer</a>
       <span class="desc">Interactive 360° parallax cubemap viewer with depth-driven square transitions, gyroscope support, and custom LDI upload.</span>
+    </li>
+    <li>
+      <a href="https://e-z-g.github.io/cube/stitcher.html">Cubemap Face Stitcher</a>
+      <span class="desc">Assemble six cube faces into the atlas the viewer's custom LDI mode loads, with per-face rotation and flip.</span>
     </li>
     <li>
       <a href="https://e-z-g.github.io/qr.html">QR Code Generator</a>


### PR DESCRIPTION
The viewer and the stitcher had a set of failures that were invisible in
normal use because nothing surfaced them.

Viewer (cube/index.html):

- Voltaic's "Alt (IMG)" and "Video (5x3)" versions pointed at a cubemapvr/
  directory that does not exist; both 404. Removed those versions and the
  now-unreachable img-seq branch in getCubemapUrls.
- loadPanorama's stale-load check returned without clearing isTransitioning
  or hiding the spinner, permanently locking the viewer. Reachable because
  the custom-upload handler force-clears the guard. Every exit path now runs
  a finally; the tween takes ownership of the flag only once the load body
  has completed.
- Load failures were console-only, leaving the previous scene up with no
  explanation. Added a dismissible error banner with a retry action.
- The location select had no mid-transition guard (the quality buttons do),
  so the dropdown and the rebuilt controls moved on while the scene did not.
  It now reverts to the current location instead of half-applying.
- Locations with `audio: null` left the previous track playing, because
  playOrCrossfadeAudio bails on a falsy URL and loadPanorama only called it
  for truthy ones. Added fadeOutAudio and always call through.
- Assets now load relatively instead of from raw.githubusercontent.com.
  They sit next to the page, so this keeps them on the Pages CDN, drops a
  cross-origin handshake, avoids raw's throttling, and makes the viewer
  runnable from a local server. (Brought forward from the pipeline work
  because it is what makes local verification possible at all.)
- uDepthBias was applied twice in the block-transition threshold, flattening
  the bias curve; removed the duplicate dummy depth texture and three
  uniforms FRAG_FADE never read.

Stitcher (cube/stitcher.html):

- Added the missing img.onerror, so a non-image file reports instead of
  silently leaving the button disabled.

Site index and README linked to /cubemap_viewer/, which 404s; the tool is at
/cube/. Repointed both and added the stitcher, which was listed nowhere.

Verified with Playwright against a local server: all three locations and
every version load with zero failed requests, the spinner always clears, the
mid-transition guard holds, and the Amateria track pauses with its src
cleared when switching to J'nanin.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JNkFRjfT5jE5AantKjhJkv