### PR TITLE
Update root README and index with full, accurate tool list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,64 @@
 # e-z-g.github.io
 
-A collection of web-based tools and interactive viewers.
+A collection of web-based tools and interactive viewers, live at
+<https://e-z-g.github.io/>. Everything is static and runs client-side in the
+browser — no build step, no server, no uploads.
 
-## Tools
+## 360° & VR
 
 - **[Cubemap VR Viewer](https://e-z-g.github.io/cube/)** — Interactive 360° parallax cubemap viewer with depth-driven square transitions, gyroscope support, and custom LDI upload.
 - **[Cubemap Face Stitcher](https://e-z-g.github.io/cube/stitcher.html)** — Assemble six cube faces into the atlas the viewer's custom LDI mode loads, with per-face rotation and flip.
-- **[QR Code Generator](https://e-z-g.github.io/qr.html)** — Generate and download QR codes in the browser.
-- **[Wine Tool](https://e-z-g.github.io/wine.html)** — Wine reference/utility tool.
-- **[VR Video](https://e-z-g.github.io/vrvid.html)** — VR video player.
-- **[Star/Planet Viewer](https://e-z-g.github.io/ev/)** — Generative space scene with star field and planet image, with PNG export.
+- **[Video Sphere Viewer](https://e-z-g.github.io/vrvid.html)** — Play any equirectangular 360° video on a sphere; pass one in with `?video=`, with gyroscope and fullscreen.
+
+## Image & video
+
+- **[Pixelator](https://e-z-g.github.io/pixelator.html)** — Nearest-neighbour image downscaler for clean pixel art.
+- **[PNG Alpha Tools](https://e-z-g.github.io/unpremultiply.html)** — Remove premultiplied alpha from PNG images, from a file or a URL.
+- **[GIF Sprite Extractor](https://e-z-g.github.io/gif2sheet.html)** — Split an animated GIF into its frames and export them as a sprite sheet.
+- **[Custom Video Scaler](https://e-z-g.github.io/vidscale.html)** — Rescale a video to arbitrary dimensions with smooth or pixelated sampling, and re-export it.
 - **[3D Print Scanimation Generator](https://e-z-g.github.io/scanimation.html)** — Interlace up to six frames into a printable base plate and sliding barrier grid, with SVG and multi-colour 3MF export.
-- **[FPQR](https://e-z-g.github.io/fpqr/)** — First-person QR experience.
+- **[Star/Planet Viewer](https://e-z-g.github.io/ev/)** — Generative space scene with star field and planet image, with PNG export.
+
+## Codes & utilities
+
+- **[Fancy-Pants QR Encoder](https://e-z-g.github.io/fpqr/)** — QR generator with custom module geometry, halftone and emoji fills, gradients, and an anatomy view of the finder, alignment, and data blocks.
+- **[Input-Optimized Passwords](https://e-z-g.github.io/ez-pw.html)** — Generate strong passwords that are quick to type on an on-screen keyboard, tuned to the keyboard layout and starting focus position.
+- **[Instant Mobile Tester](https://e-z-g.github.io/check.html)** — Paste, drop, or upload an HTML file on your phone and run it immediately in a preview.
+- **[VinoVision](https://e-z-g.github.io/wine/)** — Photograph a wine shelf to extract every visible bottle into a filterable database, with an AR finder for locating a pick back on the shelf.
+
+## Retro Mac
+
+- **[Cythera Graphics Browser](https://e-z-g.github.io/cythera/databrowser.html)** — Browse the sprites, portraits, skill icons, and tile sheets inside a Cythera Data archive.
+- **[Cythera Data Viewer](https://e-z-g.github.io/cythera/cythera_data_viewer.html)** — Expanded Cythera browser with decoded scripts, character and creature records, and full-text search across the archive.
+- **[Cythera Mobile](https://e-z-g.github.io/cythera/infinite.html)** — Cythera running on an emulated Mac OS 7.6 with touch-friendly display and speed controls.
+- **[Mac Resource Fork Browser](https://e-z-g.github.io/cythera/resource_fork_browser.html)** — Decode raw resource forks, MacBinary (`.bin`), and BinHex (`.hqx`) locally, with text, summary, and ZIP export.
+- **[JumpStart 4th Grade Player](https://e-z-g.github.io/infj4.html)** — JumpStart 4th Grade: Haunted Island, booted in an emulated Power Macintosh G3.
 
 ## Local preview
 
-Everything here is static, but the two cubemap pages load their assets relatively
-and share an ES module (`cube/atlas-layout.js`), so they need to be served rather
-than opened from disk:
+Most pages are single self-contained HTML files you can open straight from
+disk. The two cubemap pages load their assets relatively and share an ES
+module (`cube/atlas-layout.js`), so they need to be served:
 
 ```
 python3 -m http.server 8000
 ```
 
-Then open <http://localhost:8000/cube/>.
+Then open <http://localhost:8000/>.
 
-`cube/atlas-layout.js` is the single definition of the atlas format the stitcher
-writes and the viewer reads. Both layouts (5×3 and the compact 3×2) are described
-there; changing one side without the other will misalign the pole faces.
+## Repository layout
+
+| Path | Contents |
+| --- | --- |
+| `index.html` | Landing page linking every tool — update it alongside this README when adding one. |
+| `cube/` | Cubemap viewer, stitcher, `atlas-layout.js`, and the scene image sets. |
+| `cythera/` | Cythera browsers, the emulator page, and the `res/` data archive. |
+| `ev/` | Star/planet scene and its planet image. |
+| `fpqr/` | QR encoder with its own `css/` and `js/`. |
+| `wine/` | VinoVision and its sample photo. |
+| `*.html` | Standalone single-file tools. |
+
+`cube/atlas-layout.js` is the single definition of the atlas format the
+stitcher writes and the viewer reads. Both layouts (5×3 and the compact 3×2)
+are described there; changing one side without the other will misalign the
+pole faces.

--- a/index.html
+++ b/index.html
@@ -22,7 +22,17 @@
     p.subtitle {
       font-size: 0.9rem;
       color: #777;
-      margin-bottom: 2rem;
+      margin-bottom: 2.5rem;
+    }
+    h2 {
+      font-size: 0.78rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #666;
+      margin: 2.5rem 0 1rem;
+      padding-bottom: 0.4rem;
+      border-bottom: 1px solid #222;
     }
     ul {
       list-style: none;
@@ -47,44 +57,112 @@
       color: #888;
       margin-top: 0.15rem;
     }
+    footer {
+      margin-top: 3rem;
+      padding-top: 1rem;
+      border-top: 1px solid #222;
+      font-size: 0.78rem;
+      color: #666;
+    }
+    footer a {
+      font-size: inherit;
+    }
   </style>
 </head>
 <body>
   <h1>e-z-g tools</h1>
-  <p class="subtitle">A collection of web-based tools and interactive viewers.</p>
+  <p class="subtitle">A collection of web-based tools and interactive viewers. Everything runs client-side in the browser.</p>
+
+  <h2>360° &amp; VR</h2>
   <ul>
     <li>
-      <a href="https://e-z-g.github.io/cube/">Cubemap VR Viewer</a>
+      <a href="cube/">Cubemap VR Viewer</a>
       <span class="desc">Interactive 360° parallax cubemap viewer with depth-driven square transitions, gyroscope support, and custom LDI upload.</span>
     </li>
     <li>
-      <a href="https://e-z-g.github.io/cube/stitcher.html">Cubemap Face Stitcher</a>
+      <a href="cube/stitcher.html">Cubemap Face Stitcher</a>
       <span class="desc">Assemble six cube faces into the atlas the viewer's custom LDI mode loads, with per-face rotation and flip.</span>
     </li>
     <li>
-      <a href="https://e-z-g.github.io/qr.html">QR Code Generator</a>
-      <span class="desc">Generate and download QR codes in the browser.</span>
+      <a href="vrvid.html">Video Sphere Viewer</a>
+      <span class="desc">Play any equirectangular 360° video on a sphere — pass one in with <code>?video=</code>, with gyroscope and fullscreen.</span>
+    </li>
+  </ul>
+
+  <h2>Image &amp; video</h2>
+  <ul>
+    <li>
+      <a href="pixelator.html">Pixelator</a>
+      <span class="desc">Nearest-neighbour image downscaler for clean pixel art.</span>
     </li>
     <li>
-      <a href="https://e-z-g.github.io/wine.html">Wine Tool</a>
-      <span class="desc">Wine reference/utility tool.</span>
+      <a href="unpremultiply.html">PNG Alpha Tools</a>
+      <span class="desc">Remove premultiplied alpha from PNG images, from a file or a URL, entirely in the browser.</span>
     </li>
     <li>
-      <a href="https://e-z-g.github.io/vrvid.html">VR Video</a>
-      <span class="desc">VR video player.</span>
+      <a href="gif2sheet.html">GIF Sprite Extractor</a>
+      <span class="desc">Split an animated GIF into its frames and export them as a sprite sheet.</span>
     </li>
     <li>
-      <a href="https://e-z-g.github.io/ev/">Star/Planet Viewer</a>
-      <span class="desc">Generative space scene with star field and planet image, with PNG export.</span>
+      <a href="vidscale.html">Custom Video Scaler</a>
+      <span class="desc">Rescale a video to arbitrary dimensions with smooth or pixelated sampling, and re-export it.</span>
     </li>
     <li>
-      <a href="https://e-z-g.github.io/scanimation.html">3D Print Scanimation Generator</a>
+      <a href="scanimation.html">3D Print Scanimation Generator</a>
       <span class="desc">Interlace up to six frames into a printable base plate and sliding barrier grid, with SVG and multi-colour 3MF export.</span>
     </li>
     <li>
-      <a href="https://e-z-g.github.io/fpqr/">FPQR</a>
-      <span class="desc">First-person QR experience.</span>
+      <a href="ev/">Star/Planet Viewer</a>
+      <span class="desc">Generative space scene with star field and planet image, with PNG export.</span>
     </li>
   </ul>
+
+  <h2>Codes &amp; utilities</h2>
+  <ul>
+    <li>
+      <a href="fpqr/">Fancy-Pants QR Encoder</a>
+      <span class="desc">QR generator with custom module geometry, halftone and emoji fills, gradients, and an anatomy view of the finder, alignment, and data blocks.</span>
+    </li>
+    <li>
+      <a href="ez-pw.html">Input-Optimized Passwords</a>
+      <span class="desc">Generate strong passwords that are quick to type on an on-screen keyboard, tuned to the keyboard layout and starting focus position.</span>
+    </li>
+    <li>
+      <a href="check.html">Instant Mobile Tester</a>
+      <span class="desc">Paste, drop, or upload an HTML file on your phone and run it immediately in a preview.</span>
+    </li>
+    <li>
+      <a href="wine/">VinoVision</a>
+      <span class="desc">Photograph a wine shelf to extract every visible bottle into a filterable database, with an AR finder for locating a pick back on the shelf.</span>
+    </li>
+  </ul>
+
+  <h2>Retro Mac</h2>
+  <ul>
+    <li>
+      <a href="cythera/databrowser.html">Cythera Graphics Browser</a>
+      <span class="desc">Browse the sprites, portraits, skill icons, and tile sheets inside a Cythera Data archive.</span>
+    </li>
+    <li>
+      <a href="cythera/cythera_data_viewer.html">Cythera Data Viewer</a>
+      <span class="desc">Expanded Cythera browser with decoded scripts, character and creature records, and full-text search across the archive.</span>
+    </li>
+    <li>
+      <a href="cythera/infinite.html">Cythera Mobile</a>
+      <span class="desc">Cythera running on an emulated Mac OS 7.6 with touch-friendly display and speed controls.</span>
+    </li>
+    <li>
+      <a href="cythera/resource_fork_browser.html">Mac Resource Fork Browser</a>
+      <span class="desc">Decode raw resource forks, MacBinary (.bin), and BinHex (.hqx) locally, with text, summary, and ZIP export.</span>
+    </li>
+    <li>
+      <a href="infj4.html">JumpStart 4th Grade Player</a>
+      <span class="desc">JumpStart 4th Grade: Haunted Island, booted in an emulated Power Macintosh G3.</span>
+    </li>
+  </ul>
+
+  <footer>
+    Source on <a href="https://github.com/e-z-g/e-z-g.github.io">GitHub</a>.
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
The landing page and README listed two pages that do not exist (qr.html, wine.html — the wine tool lives at wine/) while omitting ten pages that do.

- Fix the wine link and drop the dead QR entry
- Add the missing tools: Video Sphere Viewer, Pixelator, PNG Alpha Tools, GIF Sprite Extractor, Custom Video Scaler, Fancy-Pants QR Encoder, Input-Optimized Passwords, Instant Mobile Tester, the four Cythera / retro Mac pages, and the JumpStart player
- Group entries into 360° & VR, Image & video, Codes & utilities, and Retro Mac on both pages
- Switch index.html to relative links so it works when served locally
- Add a repository layout table to the README