### PR TITLE
Rename cythera_mobile.html to mobile.html and fix its input handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 repomix_output.md
+cythera/infinite-mac

--- a/cythera/mobile.html
+++ b/cythera/mobile.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <title>Cythera Mobile - Stable OS 7.6</title>
+    <title>Cythera — Mac OS 7.6</title>
     <style>
         body, html {
             margin: 0; padding: 0;
@@ -11,6 +11,7 @@
             background-color: #000;
             overflow: hidden;
             touch-action: none;
+            user-select: none; -webkit-user-select: none; -webkit-touch-callout: none;
             font-family: 'Courier New', Courier, monospace;
         }
  
@@ -65,7 +66,14 @@
         #mac-iframe { image-rendering: -webkit-optimize-contrast; image-rendering: crisp-edges; image-rendering: pixelated; }
         #gl-canvas { pointer-events: none; display: none; }
         #touch-overlay { z-index: 10; touch-action: none; pointer-events: none; }
-        #touch-overlay.active { pointer-events: auto; }
+        /* The emulated Mac draws its own cursor inside the screen, so the
+           browser's arrow on top of it gives you two pointers that disagree.
+           It is hidden while the pointer maps straight onto the screen, and
+           shown again in Pan View, where the emulated cursor stays on the
+           crosshair and the real one is what you drag the view with. */
+        #touch-overlay.active { pointer-events: auto; cursor: none; }
+        #touch-overlay.active.pan-cursor { cursor: grab; }
+        #touch-overlay.active.pan-cursor.panning { cursor: grabbing; }
  
  
         /* TOP LAYER */
@@ -96,7 +104,7 @@
         .resize-handle { position: absolute; bottom: 0; right: 0; width: 20px; height: 20px; cursor: se-resize; background: linear-gradient(135deg, transparent 50%, #C4A464 50%); touch-action: none; }
  
         .btn-grid { display: grid; gap: 4px; width: 100%; height: 100%; grid-template-columns: repeat(3, 1fr); grid-template-rows: repeat(3, 1fr); }
-        .gesture-area { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: none; background: rgba(255, 230, 136, 0.05); touch-action: none; }
+        .gesture-area { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: none; background: rgba(255, 230, 136, 0.05); touch-action: none; cursor: crosshair; }
         #joy-base { position: absolute; width: 50%; height: 50%; max-width: 100px; max-height: 100px; border: 2px solid rgba(252, 230, 136, 0.3); border-radius: 50%; transform: translate(-50%, -50%); display: none; pointer-events: none; }
         #joy-stick { position: absolute; width: 25%; height: 25%; max-width: 40px; max-height: 40px; background: rgba(252, 230, 136, 0.6); border-radius: 50%; transform: translate(-50%, -50%); display: none; pointer-events: none; }
         #gesture-canvas { width: 100%; height: 100%; pointer-events: none; }
@@ -187,7 +195,7 @@
  
     <div id="start-overlay">
         <div id="start-overlay-text">
-            <h1 id="start-title">▶ TAP TO START</h1>
+            <h1 id="start-title">▶ TAP OR CLICK TO START</h1>
             <p id="start-sub">Mac OS 7.6 • Quadra 650</p>
             <p id="start-status">Downloading the emulator and the Cythera disk…</p>
         </div>
@@ -263,7 +271,7 @@
     <div id="help-panel" hidden>
         <div id="help-inner">
             <button id="help-close" aria-label="Close">✕</button>
-            <h2>Cythera Mobile</h2>
+            <h2>Cythera</h2>
 
             <h3>Moving and acting</h3>
             <p>The two floating windows are the numeric keypad and Cythera's action keys. Drag a
@@ -272,11 +280,23 @@
             <ul id="gesture-legend"></ul>
 
             <h3>Touching the screen</h3>
-            <p><b>Direct</b> puts the pointer where your finger is — best for the game world.
-            <b>Trackpad</b> moves the pointer relatively and holds for 0.4 s to start a drag —
-            best for menus and small targets. <b>Pan View</b> keeps the pointer centred and moves
-            the view instead. Two fingers pinch to zoom anywhere, and a two-finger tap is a
-            right-click.</p>
+            <p>These three settings describe what a <i>finger</i> does. <b>Direct</b> puts the
+            pointer where your finger is — best for the game world. <b>Trackpad</b> moves the
+            pointer relatively and holds for 0.4 s to start a drag — best for menus and small
+            targets. <b>Pan View</b> keeps the pointer on the crosshair and moves the view
+            instead. Two fingers pinch to zoom anywhere, and a two-finger tap is a right-click.</p>
+
+            <h3>Mouse and keyboard</h3>
+            <p>A mouse already points, so it is always Direct — the pointer inside the Mac
+            follows yours, including while no button is down, and both buttons go through as
+            themselves. Trackpad means nothing to a mouse and is ignored by one; Pan View still
+            applies, and there a drag moves the view. The <b>scroll wheel zooms</b>, which is the
+            desktop half of the pinch.</p>
+            <p>Your keyboard is passed straight to the emulated Mac, so Cythera's numeric keypad
+            and its letter commands work as they did on the original — the floating windows are
+            for when you have no keyboard, not instead of one. The browser keeps <code>F5</code>,
+            <code>F11</code>, <code>F12</code> and its own reload/new-tab/close shortcuts.
+            Everything on this page can also be reached with Tab and Enter.</p>
 
             <h3>Loading your own Cythera</h3>
             <p><b>Drag a file onto the emulator</b> — a disk image (<code>.dsk</code>,
@@ -387,6 +407,12 @@
         // the TAP TO START overlay, and the emulator_unpause sent on tap was
         // unpausing something that had never been paused.
         u.searchParams.set('paused', 'true');
+        // The de-dither filter needs the frames, and the frames are also the
+        // only place the emulator states the resolution it actually came up
+        // with. They are not free: a whole screen is copied across origins on
+        // every drawn frame. The parameter is read once at boot, so switching
+        // it with the filter would mean restarting the Mac to change a display
+        // setting -- a worse trade than the copies.
         u.searchParams.set('screen_update_messages', 'true');
         u.searchParams.set('settings', JSON.stringify({
             swapControlAndCommand: false,
@@ -425,17 +451,28 @@
         if (e.origin !== EMBED_ORIGIN || !e.data) return;
         if (e.data.type === 'emulator_loaded') {
             emulatorReady = true;
-            setStartStatus('Ready — tap to play', true);
+            setStartStatus('Ready — tap or click to play', true);
             const queued = pendingMessages;
             pendingMessages = [];
             for (const m of queued) post(m);
+        } else if (e.data.type === 'emulator_screen') {
+            // The only place the emulated screen's real size is ever stated.
+            // Every touch and every click is turned into a coordinate on that
+            // screen, so a page that guesses it wrong puts the pointer
+            // somewhere else entirely -- which is what happened whenever the
+            // emulator settled on a resolution other than the one asked for.
+            if (e.data.width && e.data.height) applyScreenSize(e.data.width, e.data.height);
+            drawScreen(e.data);
         }
     });
 
     function startEmulator() {
         startOverlay.style.display = 'none';
         post({ type: 'emulator_unpause' });
-        // A click to give the emulated Mac keyboard focus.
+        // A click to wake the emulated Mac up. It has to happen *somewhere*,
+        // and with no move first that somewhere is 0,0 -- the corner of the
+        // menu bar, so starting the game pulled down the Apple menu.
+        setCursor(screenWidth / 2, screenHeight / 2);
         post({ type: 'emulator_mouse_down', button: 0 });
         post({ type: 'emulator_mouse_up', button: 0 });
         touchOverlay.classList.add('active');
@@ -455,17 +492,34 @@
     // mapped to the wrong place on the emulated screen.
     const baseWidth = 640;
     const baseHeight = Math.round(baseWidth * (window.innerHeight / window.innerWidth));
+    // What the machine actually came up with. It starts as the size that was
+    // asked for and is corrected by the first frame the emulator reports.
+    let screenWidth = baseWidth, screenHeight = baseHeight;
     let cssScale = 1;
     scaleTarget.style.width = `${baseWidth}px`;
     scaleTarget.style.height = `${baseHeight}px`;
     glCanvas.width = baseWidth; glCanvas.height = baseHeight;
 
+    function applyScreenSize(w, h) {
+        if (w === screenWidth && h === screenHeight) return;
+        screenWidth = w; screenHeight = h;
+        // The iframe fills #scale-target, so making that box the size of the
+        // emulated screen makes one pixel here one pixel there, and the
+        // coordinate arithmetic below exact rather than approximately right.
+        scaleTarget.style.width = `${w}px`;
+        scaleTarget.style.height = `${h}px`;
+        glCanvas.width = w; glCanvas.height = h;
+        if (shaderReady && texSizeLocation) gl.uniform2f(texSizeLocation, w, h);
+        setCursor(cursorX, cursorY);
+        applyCssScale();
+    }
+
     function applyCssScale() {
         // Fit rather than fill, so a rotated phone letterboxes instead of
         // cropping the menu bar off the top of the emulated screen.
-        cssScale = Math.min(window.innerWidth / baseWidth, window.innerHeight / baseHeight);
-        const left = Math.max(0, (window.innerWidth - baseWidth * cssScale) / 2);
-        const top = Math.max(0, (window.innerHeight - baseHeight * cssScale) / 2);
+        cssScale = Math.min(window.innerWidth / screenWidth, window.innerHeight / screenHeight);
+        const left = Math.max(0, (window.innerWidth - screenWidth * cssScale) / 2);
+        const top = Math.max(0, (window.innerHeight - screenHeight * cssScale) / 2);
         scaleTarget.style.transform = `translate(${left}px, ${top}px) scale(${cssScale})`;
     }
     applyCssScale();
@@ -512,8 +566,25 @@
     function pressKey(code) { heldKeys.add(code); sendKey(code, true); }
     function releaseKey(code) { if (heldKeys.delete(code)) sendKey(code, false); }
     function releaseAllKeys() { for (const code of Array.from(heldKeys)) releaseKey(code); }
-    document.addEventListener('visibilitychange', () => { if (document.hidden) releaseAllKeys(); });
-    window.addEventListener('blur', releaseAllKeys);
+    // A mouse button is as bad to leave down as a key: in the Finder it is a
+    // window being dragged for as long as the page is in the background.
+    function releaseEverything() { releaseAllKeys(); releaseAllButtons(); }
+    document.addEventListener('visibilitychange', () => { if (document.hidden) releaseEverything(); });
+    window.addEventListener('blur', releaseEverything);
+
+    // Every control on this page is a <div>, so each one has to say how it is
+    // operated. Doing that in one place is what stops a control from being
+    // wired to `touchend` alone -- invisible to a mouse -- which is what the
+    // keyboard button was, and gives all of them Enter/Space for free.
+    function onTap(el, fn) {
+        if (!el) return;
+        el.addEventListener('pointerdown', e => { e.preventDefault(); fn(e); });
+        el.tabIndex = 0;
+        el.setAttribute('role', 'button');
+        el.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fn(e); }
+        });
+    }
 
     // Windows Drag/Resize/Toggles
     // Pointer events rather than touch events: the same code now works with a
@@ -571,12 +642,10 @@
         resizeHandle.addEventListener('pointerup', endResize);
         resizeHandle.addEventListener('pointercancel', endResize);
 
-        toggleBtn.addEventListener('pointerdown', e => {
-            e.preventDefault(); e.stopPropagation();
+        onTap(toggleBtn, () => {
             setWindowMode(win, toggleBtn.classList.toggle('active'));
             saveHudLayout();
         });
-        win.addEventListener('touchstart', e => e.stopPropagation()); win.addEventListener('touchmove', e => e.stopPropagation()); win.addEventListener('touchend', e => e.stopPropagation());
     });
 
     function setWindowMode(win, gestures) {
@@ -589,6 +658,7 @@
             // A dragging finger that leaves the joystick still has to stop the
             // character; releasing every held key when the mode changes is the
             // cheap way to be sure nothing is left down.
+            stopMovement();
             releaseAllKeys();
         } else { btnGrid.style.display = 'grid'; gestureArea.style.display = 'none'; }
     }
@@ -639,31 +709,49 @@
         if (angleDeg >= -112.5 && angleDeg < -67.5) return 'Numpad8'; if (angleDeg >= -67.5 && angleDeg < -22.5) return 'Numpad9'; 
         return null;
     }
-    moveZone.addEventListener('touchstart', e => {
+    // Pointer events, so the joystick works under a mouse as well as a thumb,
+    // and so a drag that leaves the window keeps steering instead of stopping
+    // dead with the direction key still held.
+    let joyId = null;
+    function joyPoint(e) {
         const rect = moveZone.getBoundingClientRect();
-        moveStartX = e.touches[0].clientX - rect.left; moveStartY = e.touches[0].clientY - rect.top;
-        joyBase.style.left = `${moveStartX}px`; joyBase.style.top = `${moveStartY}px`; joyStick.style.left = `${moveStartX}px`; joyStick.style.top = `${moveStartY}px`;
+        return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    }
+    moveZone.addEventListener('pointerdown', e => {
+        if (joyId !== null) return;
+        e.preventDefault();
+        joyId = e.pointerId;
+        moveZone.setPointerCapture?.(e.pointerId);
+        const p = joyPoint(e);
+        moveStartX = p.x; moveStartY = p.y;
+        joyBase.style.left = `${moveStartX}px`; joyBase.style.top = `${moveStartY}px`;
+        joyStick.style.left = `${moveStartX}px`; joyStick.style.top = `${moveStartY}px`;
         joyBase.style.display = 'block'; joyStick.style.display = 'block';
     });
-    moveZone.addEventListener('touchmove', e => {
-        const rect = moveZone.getBoundingClientRect();
-        let dx = (e.touches[0].clientX - rect.left) - moveStartX, dy = (e.touches[0].clientY - rect.top) - moveStartY;
-        let dist = Math.hypot(dx, dy), angleDeg = Math.atan2(dy, dx) * 180 / Math.PI;
-        let displayDist = Math.min(dist, moveZone.offsetWidth / 3);
-        joyStick.style.left = `${moveStartX + Math.cos(angleDeg * Math.PI/180) * displayDist}px`;
-        joyStick.style.top = `${moveStartY + Math.sin(angleDeg * Math.PI/180) * displayDist}px`;
-        let newKey = applyMovementKey(angleDeg, dist);
+    moveZone.addEventListener('pointermove', e => {
+        if (joyId !== e.pointerId) return;
+        e.preventDefault();
+        const p = joyPoint(e);
+        const dx = p.x - moveStartX, dy = p.y - moveStartY;
+        const dist = Math.hypot(dx, dy), angleDeg = Math.atan2(dy, dx) * 180 / Math.PI;
+        const displayDist = Math.min(dist, moveZone.offsetWidth / 3);
+        joyStick.style.left = `${moveStartX + Math.cos(angleDeg * Math.PI / 180) * displayDist}px`;
+        joyStick.style.top = `${moveStartY + Math.sin(angleDeg * Math.PI / 180) * displayDist}px`;
+        const newKey = applyMovementKey(angleDeg, dist);
         if (newKey !== currentMoveKey) {
             if (currentMoveKey) releaseKey(currentMoveKey);
             if (newKey) pressKey(newKey);
             currentMoveKey = newKey;
         }
     });
-    function stopMovement() {
+    function stopMovement(e) {
+        if (e && joyId !== null && e.pointerId !== joyId) return;
+        joyId = null;
         if (currentMoveKey) { releaseKey(currentMoveKey); currentMoveKey = null; }
         joyBase.style.display = 'none'; joyStick.style.display = 'none';
     }
-    moveZone.addEventListener('touchend', stopMovement); moveZone.addEventListener('touchcancel', stopMovement);
+    moveZone.addEventListener('pointerup', stopMovement);
+    moveZone.addEventListener('pointercancel', stopMovement);
  
     /* ---- Gesture Logic -------------------------------------------------
        A stroke is reduced to the sequence of directions it turns through --
@@ -701,24 +789,49 @@
     let gesturePoints = [];
     function resizeGestureCanvas() { gestureCanvas.width = actionZone.clientWidth; gestureCanvas.height = actionZone.clientHeight; }
     function showToast(text) { actionToast.textContent = text; actionToast.style.opacity = '1'; setTimeout(() => actionToast.style.opacity = '0', 700); }
-    actionZone.addEventListener('touchstart', e => {
-        const rect = actionZone.getBoundingClientRect(); gesturePoints = [{ x: e.touches[0].clientX - rect.left, y: e.touches[0].clientY - rect.top }];
-        gCtx.clearRect(0, 0, gestureCanvas.width, gestureCanvas.height); gCtx.beginPath(); gCtx.moveTo(gesturePoints[0].x, gesturePoints[0].y); gCtx.strokeStyle = '#FCE688'; gCtx.lineWidth = 4; gCtx.lineCap = 'round'; gCtx.lineJoin = 'round';
+    // Same again: a stroke can be drawn with a mouse, a stylus or a finger,
+    // and pointer capture means one that runs off the edge of the window is
+    // still the stroke you drew rather than half of it.
+    let gestureId = null;
+    function gesturePoint(e) {
+        const rect = actionZone.getBoundingClientRect();
+        return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    }
+    function clearStroke() { gCtx.clearRect(0, 0, gestureCanvas.width, gestureCanvas.height); }
+    actionZone.addEventListener('pointerdown', e => {
+        if (gestureId !== null) return;
+        e.preventDefault();
+        gestureId = e.pointerId;
+        actionZone.setPointerCapture?.(e.pointerId);
+        gesturePoints = [gesturePoint(e)];
+        clearStroke();
+        gCtx.beginPath(); gCtx.moveTo(gesturePoints[0].x, gesturePoints[0].y);
+        gCtx.strokeStyle = '#FCE688'; gCtx.lineWidth = 4; gCtx.lineCap = 'round'; gCtx.lineJoin = 'round';
     });
-    actionZone.addEventListener('touchmove', e => {
-        const rect = actionZone.getBoundingClientRect(); const pt = { x: e.touches[0].clientX - rect.left, y: e.touches[0].clientY - rect.top };
+    actionZone.addEventListener('pointermove', e => {
+        if (gestureId !== e.pointerId) return;
+        e.preventDefault();
+        const pt = gesturePoint(e);
         gesturePoints.push(pt); gCtx.lineTo(pt.x, pt.y); gCtx.stroke();
     });
-    actionZone.addEventListener('touchend', e => {
-        gCtx.clearRect(0, 0, gestureCanvas.width, gestureCanvas.height);
-        if(gesturePoints.length === 0) return;
+    actionZone.addEventListener('pointercancel', e => {
+        if (gestureId !== e.pointerId) return;
+        gestureId = null; gesturePoints = []; clearStroke();
+    });
+    actionZone.addEventListener('pointerup', e => {
+        if (gestureId !== e.pointerId) return;
+        gestureId = null;
+        clearStroke();
+        if (gesturePoints.length === 0) return;
         let dirs = "", currentDir = null, lastPt = gesturePoints[0];
-        let totalDist = Math.hypot(gesturePoints[gesturePoints.length-1].x - gesturePoints[0].x, gesturePoints[gesturePoints.length-1].y - gesturePoints[0].y);
+        const first = gesturePoints[0], last = gesturePoints[gesturePoints.length - 1];
+        const totalDist = Math.hypot(last.x - first.x, last.y - first.y);
         for (let i = 1; i < gesturePoints.length; i++) {
-            let dx = gesturePoints[i].x - lastPt.x, dy = gesturePoints[i].y - lastPt.y;
+            const dx = gesturePoints[i].x - lastPt.x, dy = gesturePoints[i].y - lastPt.y;
             if (Math.abs(dx) > 15 || Math.abs(dy) > 15) {
-                let dir = Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'R' : 'L') : (dy > 0 ? 'D' : 'U');
-                if (dir !== currentDir) { dirs += dir; currentDir = dir; } lastPt = gesturePoints[i];
+                const dir = Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'R' : 'L') : (dy > 0 ? 'D' : 'U');
+                if (dir !== currentDir) { dirs += dir; currentDir = dir; }
+                lastPt = gesturePoints[i];
             }
         }
         const hit = recogniseGesture(dirs, totalDist < 15 && gesturePoints.length < 10);
@@ -745,7 +858,7 @@
     // the script had installed a single touch handler. The page came up as a
     // dead emulator with no controls at all. A de-dithering filter is a nicety;
     // it must not be able to take the page down with it.
-    let texture = null, shaderProgram = null;
+    let texture = null, shaderProgram = null, texSizeLocation = null;
     const shaderReady = (() => {
         if (!gl) return false;
         try {
@@ -767,7 +880,7 @@
             const positionBuffer = gl.createBuffer(); gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer); gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, -1,1, 1,-1, 1,1]), gl.STATIC_DRAW);
             const positionLocation = gl.getAttribLocation(shaderProgram, "a_position"); gl.enableVertexAttribArray(positionLocation); gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
             texture = gl.createTexture(); gl.bindTexture(gl.TEXTURE_2D, texture); gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST); gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST); gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE); gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-            const texSizeLocation = gl.getUniformLocation(shaderProgram, "u_texSize"); gl.uniform2f(texSizeLocation, baseWidth, baseHeight);
+            texSizeLocation = gl.getUniformLocation(shaderProgram, "u_texSize"); gl.uniform2f(texSizeLocation, screenWidth, screenHeight);
             return true;
         } catch (err) {
             console.warn('De-dither filter unavailable:', err && err.message);
@@ -783,8 +896,7 @@
         else { glCanvas.style.display = 'block'; iframe.style.opacity = '0.01'; filterToggle.innerHTML = '<span class="emoji">📺</span>Dedith'; }
         savePrefs({ crisp: isCrisp });
     }
-    filterToggle.addEventListener('pointerdown', e => {
-        e.preventDefault();
+    onTap(filterToggle, () => {
         if (!shaderReady) { showToast('No WebGL here'); return; }
         setCrisp(!isCrisp);
     });
@@ -792,15 +904,22 @@
         filterToggle.classList.add('disabled');
         filterToggle.title = 'WebGL is not available in this browser';
     }
-    window.addEventListener("message", e => {
-        if (e.origin !== EMBED_ORIGIN) return;
-        if (!isCrisp && shaderReady && e.data && e.data.type === "emulator_screen" && e.data.data) {
-            try { gl.bindTexture(gl.TEXTURE_2D, texture); gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, e.data.width||baseWidth, e.data.height||baseHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(e.data.data)); gl.drawArrays(gl.TRIANGLES, 0, 6); } catch (err) {}
-        }
-    });
+    // Called from the one message listener at the top, which is also where
+    // the emulator's real screen size is picked up. Two listeners for the same
+    // message meant two places that had to agree about what a frame is.
+    function drawScreen(msg) {
+        if (isCrisp || !shaderReady || !msg.data) return;
+        try {
+            gl.bindTexture(gl.TEXTURE_2D, texture);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, msg.width || screenWidth, msg.height || screenHeight,
+                          0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(msg.data));
+            gl.drawArrays(gl.TRIANGLES, 0, 6);
+        } catch (err) { /* a frame that will not upload is not worth reporting */ }
+    }
 
     // Settings Drawer Buttons
-    document.getElementById('settings-handle').addEventListener('pointerdown', e => { e.preventDefault(); document.getElementById('settings-drawer').classList.toggle('collapsed'); });
+    onTap(document.getElementById('settings-handle'),
+          () => document.getElementById('settings-drawer').classList.toggle('collapsed'));
  
     let touchMode = 0;
     const touchModeToggle = document.getElementById('touch-mode-toggle');
@@ -809,42 +928,55 @@
         touchMode = ((mode % 3) + 3) % 3;
         touchModeToggle.innerHTML = touchModeLabels[touchMode];
         centerCrosshair.style.display = (touchMode === 2) ? 'block' : 'none';
+        touchOverlay.classList.toggle('pan-cursor', touchMode === 2);
+        // Changing what a drag means in the middle of one would otherwise
+        // leave the button down in the emulated Mac.
+        releaseAllButtons();
         if (touchMode === 2) updatePanCursor();
         savePrefs({ touchMode: touchMode });
     }
-    touchModeToggle.addEventListener('pointerdown', e => { e.preventDefault(); setTouchMode(touchMode + 1); });
+    onTap(touchModeToggle, () => setTouchMode(touchMode + 1));
 
     let isPaused = false;
     const pauseBtn = document.getElementById('pause-btn');
-    pauseBtn.addEventListener('pointerdown', e => {
-        e.preventDefault(); isPaused = !isPaused;
+    onTap(pauseBtn, () => {
+        isPaused = !isPaused;
+        // A paused emulator cannot receive a keyup or a mouseup, so let go of
+        // everything before it stops listening.
+        if (isPaused) releaseEverything();
         post({ type: isPaused ? 'emulator_pause' : 'emulator_unpause' });
-        // A paused emulator cannot receive a keyup, so release first.
-        if (isPaused) releaseAllKeys();
         pauseBtn.innerHTML = isPaused ? '<span class="emoji">▶️</span>Play' : '<span class="emoji">⏸️</span>Pause';
     });
 
     // A native confirm() is a system-modal dialog: on iOS it takes focus away
     // mid-gesture and leaves the touch handlers here with a pointer they never
     // see released. This one is part of the page.
+    const modalEl = document.getElementById('modal-confirm');
+    const modalInput = document.getElementById('modal-input');
+    let modalOnOk = null;
+    // Wired once. Adding and removing a pair of listeners per call meant the
+    // buttons behaved differently depending on how the dialog was opened, and
+    // could not be reached from a keyboard at all.
+    function closeModal() { modalEl.hidden = true; modalOnOk = null; }
+    function confirmModal() {
+        const value = modalInput.hidden ? undefined : modalInput.value;
+        const fn = modalOnOk;
+        closeModal();
+        if (fn) fn(value);
+    }
+    onTap(document.getElementById('modal-ok'), confirmModal);
+    onTap(document.getElementById('modal-cancel'), closeModal);
+    modalInput.addEventListener('keydown', e => {
+        if (e.key === 'Enter') { e.preventDefault(); confirmModal(); }
+    });
+
     function askModal(text, onOk, initialValue) {
-        const modal = document.getElementById('modal-confirm');
-        const input = document.getElementById('modal-input');
         document.getElementById('modal-text').textContent = text;
-        input.hidden = initialValue === undefined;
-        if (!input.hidden) input.value = initialValue;
-        modal.hidden = false;
-        if (!input.hidden) input.focus();
-        const ok = document.getElementById('modal-ok'), cancel = document.getElementById('modal-cancel');
-        const close = () => {
-            modal.hidden = true;
-            ok.removeEventListener('pointerdown', yes);
-            cancel.removeEventListener('pointerdown', no);
-        };
-        const yes = e => { e.preventDefault(); close(); onOk(input.hidden ? undefined : input.value); };
-        const no = e => { e.preventDefault(); close(); };
-        ok.addEventListener('pointerdown', yes);
-        cancel.addEventListener('pointerdown', no);
+        modalInput.hidden = initialValue === undefined;
+        if (!modalInput.hidden) modalInput.value = initialValue;
+        modalOnOk = onOk;
+        modalEl.hidden = false;
+        if (!modalInput.hidden) modalInput.focus();
     }
     const askConfirm = (text, onYes) => askModal(text, onYes);
 
@@ -862,8 +994,7 @@
 
     const speedBtn = document.getElementById('speed-btn');
     function paintSpeed() { speedBtn.innerHTML = `<span class="emoji">⚡</span>${speedName(currentSpeed)}`; }
-    speedBtn.addEventListener('pointerdown', e => {
-        e.preventDefault();
+    onTap(speedBtn, () => {
         const i = SPEEDS.findIndex(([v]) => v === currentSpeed);
         const [next, label] = SPEEDS[(i + 1) % SPEEDS.length];
         askConfirm(`Run the emulator at ${label}?\n\nThis restarts the Mac, and anything not saved inside Cythera is lost.`, () => {
@@ -878,8 +1009,7 @@
     // There is no way for this page to do that: audio belongs to the emulator
     // in a cross-origin iframe, and the embed API has no message for it.
     const fullscreenBtn = document.getElementById('fullscreen-btn');
-    fullscreenBtn.addEventListener('pointerdown', e => {
-        e.preventDefault();
+    onTap(fullscreenBtn, () => {
         const el = document.documentElement;
         if (document.fullscreenElement) (document.exitFullscreen || document.webkitExitFullscreen || function(){}).call(document);
         else (el.requestFullscreen || el.webkitRequestFullscreen || function(){}).call(el);
@@ -894,8 +1024,7 @@
     // So a blob: URL made from a local file cannot work, and neither can a
     // private address -- which is exactly why the local Cythera files are
     // loaded by dropping them on the emulator instead (see the drop handler).
-    document.getElementById('disk-btn').addEventListener('pointerdown', e => {
-        e.preventDefault();
+    onTap(document.getElementById('disk-btn'), () => {
         askModal('Disk image URL to mount.\n\nIt has to be reachable from the public internet: infinitemac.org fetches it, not this browser.',
             url => {
                 if (!url) return;
@@ -906,11 +1035,11 @@
     });
 
     const helpPanel = document.getElementById('help-panel');
-    document.getElementById('help-btn').addEventListener('pointerdown', e => { e.preventDefault(); helpPanel.hidden = false; });
-    document.getElementById('help-close').addEventListener('pointerdown', e => { e.preventDefault(); helpPanel.hidden = true; });
+    onTap(document.getElementById('help-btn'), () => { helpPanel.hidden = false; });
+    onTap(document.getElementById('help-close'), () => { helpPanel.hidden = true; });
     helpPanel.addEventListener('pointerdown', e => { if (e.target === helpPanel) helpPanel.hidden = true; });
     document.addEventListener('keydown', e => {
-        if (e.key === 'Escape') { helpPanel.hidden = true; document.getElementById('modal-confirm').hidden = true; }
+        if (e.key === 'Escape') { helpPanel.hidden = true; closeModal(); }
     });
 
     // Keys & Buttons
@@ -932,154 +1061,329 @@
         btn.addEventListener('keyup', e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); releaseKey(code); } });
     });
     const kbInput = document.getElementById('hidden-keyboard');
-    document.getElementById('kb-toggle').addEventListener('touchend', (e) => { e.preventDefault(); kbInput.focus(); });
+    const kbToggle = document.getElementById('kb-toggle');
+    // This one listens for `click` rather than going through onTap: a phone
+    // only raises its keyboard for a focus() that happens inside a real user
+    // gesture, and preventDefault()ing pointerdown stops it from being one.
+    // It listened for `touchend` alone before, so on a desktop it did nothing.
+    kbToggle.addEventListener('click', () => kbInput.focus());
+    kbToggle.tabIndex = 0;
+    kbToggle.setAttribute('role', 'button');
+    kbToggle.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); kbInput.focus(); }
+    });
     const charToCode = { 'a':'KeyA', 'b':'KeyB', 'c':'KeyC', 'd':'KeyD', 'e':'KeyE', 'f':'KeyF', 'g':'KeyG', 'h':'KeyH', 'i':'KeyI', 'j':'KeyJ', 'k':'KeyK', 'l':'KeyL', 'm':'KeyM', 'n':'KeyN', 'o':'KeyO', 'p':'KeyP', 'q':'KeyQ', 'r':'KeyR', 's':'KeyS', 't':'KeyT', 'u':'KeyU', 'v':'KeyV', 'w':'KeyW', 'x':'KeyX', 'y':'KeyY', 'z':'KeyZ', '1':'Digit1', '2':'Digit2', '3':'Digit3', '4':'Digit4', '5':'Digit5', '6':'Digit6', '7':'Digit7', '8':'Digit8', '9':'Digit9', '0':'Digit0', ' ':'Space', 'backspace':'Backspace', 'enter':'Enter' };
     kbInput.addEventListener('keydown', (e) => { let code = e.code || charToCode[e.key.toLowerCase()]; if(code && code!=='Unidentified') pressKey(code); });
     kbInput.addEventListener('keyup', (e) => { let code = e.code || charToCode[e.key.toLowerCase()]; if(code && code!=='Unidentified') releaseKey(code); });
     kbInput.addEventListener('blur', () => kbInput.value = '');
  
  
-    // --- ENHANCED TOUCH & DRAG LOGIC ---
+    /* ---- Pointing at the emulated screen --------------------------------
+       One code path for a finger, a stylus and a mouse.
+
+       This was three `touch*` handlers, which is why the page could not be
+       used with a mouse at all: #touch-overlay is stretched over the iframe so
+       that it can catch touches, so every click landed on the overlay -- and
+       the overlay listened for nothing a mouse produces. The emulator was
+       there on the screen, plainly visible, and unclickable.
+
+       The three touch modes describe what a *finger* does. A mouse or a stylus
+       already points, so it is always Direct; Trackpad, which exists to move a
+       pointer you cannot put your finger on, means nothing to one. Pan View
+       applies to both: there, dragging moves the view. */
     let pzScale = 1, pzX = 0, pzY = 0;
-    let startDist = 0, initialPzScale = 1, initialPzX = 0, initialPzY = 0, pinchCenterX = 0, pinchCenterY = 0;
-    
-    // Drag control variables
-    let isLeftDown = false;
+    let cursorX = baseWidth / 2, cursorY = baseHeight / 2;
+
+    const FINGER_OFFSET_Y = -12;   // a fingertip covers what it is aiming at
+    const TAP_MS = 350;            // longer than this is a press, not a tap
+    const TAP_SLOP = 8;            // and further than this is a drag
+
+    const pointers = new Map();    // live pointers, in the order they arrived
+    const isPrecise = e => e.pointerType === 'mouse' || e.pointerType === 'pen';
+    const modeFor = e => (isPrecise(e) && touchMode === 1) ? 0 : touchMode;
+
+    let primaryId = null, startX = 0, startY = 0, lastX = 0, lastY = 0;
+    let gestureStart = 0, isTwoFingerTap = false, isClickCandidate = false;
     let dragTimer = null;
-    let touchStartTime = 0;
-    let isClickCandidate = false, isTwoFingerTap = false;
-    let cursorX = baseWidth / 2, cursorY = baseHeight / 2, lastTouchX = 0, lastTouchY = 0;
- 
-    function getEmulatorCoords(clientX, clientY) {
+    let pinchDist = 0, initialPzScale = 1, initialPzX = 0, initialPzY = 0;
+    let pinchCenterX = 0, pinchCenterY = 0;
+
+    // Which buttons are down inside the emulated Mac. Nothing tracked this, so
+    // a gesture the browser took over -- a system edge swipe, a call arriving,
+    // a window losing focus mid-drag -- left the button down for good: in the
+    // Finder, a window dragged forever; in Cythera, an item never let go of.
+    const heldButtons = new Set();
+    function pressButton(b) { if (!heldButtons.has(b)) { heldButtons.add(b); mouseButton(b, true); } }
+    function releaseButton(b) { if (heldButtons.delete(b)) mouseButton(b, false); }
+    function releaseAllButtons() { for (const b of Array.from(heldButtons)) releaseButton(b); }
+    function clickOnce(button) { pressButton(button); setTimeout(() => releaseButton(button), 50); }
+    const buttonOf = e => (e.button === 2 ? 2 : e.button === 1 ? 1 : 0);
+
+    function getEmulatorCoords(clientX, clientY, offsetY) {
+        // #scale-target *is* the emulated screen, and its rect already carries
+        // both the fit-to-window scale and the pinch zoom.
         const rect = scaleTarget.getBoundingClientRect();
-        const relX = clientX - rect.left; const relY = clientY - rect.top;
-        const fatFingerOffsetMacY = -12; 
-        const macX = relX / (rect.width / baseWidth);
-        const macY = (relY / (rect.height / baseHeight)) + fatFingerOffsetMacY;
-        return { x: macX, y: macY };
+        const sx = (rect.width / screenWidth) || 1, sy = (rect.height / screenHeight) || 1;
+        return {
+            x: (clientX - rect.left) / sx,
+            y: (clientY - rect.top) / sy + (offsetY || 0),
+        };
     }
- 
-    function updatePanCursor() {
-        const centerClientX = window.innerWidth / 2, centerClientY = window.innerHeight / 2;
-        const coords = getEmulatorCoords(centerClientX, centerClientY);
-        cursorX = coords.x; cursorY = coords.y;
+
+    function setCursor(x, y) {
+        cursorX = Math.max(0, Math.min(screenWidth - 1, x));
+        cursorY = Math.max(0, Math.min(screenHeight - 1, y));
         moveMouse(cursorX, cursorY);
     }
- 
-    touchOverlay.addEventListener('touchstart', (e) => {
-        e.preventDefault();
-        if (e.touches.length === 2) {
-            // Cancel any active drag
-            if (isLeftDown) {
-                mouseButton(0, false);
-                isLeftDown = false;
-            }
-            if (dragTimer) { clearTimeout(dragTimer); dragTimer = null; }
-            
-            startDist = Math.hypot(e.touches[0].clientX - e.touches[1].clientX, e.touches[0].clientY - e.touches[1].clientY);
-            initialPzScale = pzScale; initialPzX = pzX; initialPzY = pzY;
-            pinchCenterX = (e.touches[0].clientX + e.touches[1].clientX) / 2; pinchCenterY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-            isClickCandidate = false; isTwoFingerTap = true; touchStartTime = Date.now();
-        } else if (e.touches.length === 1) {
-            isClickCandidate = true; isTwoFingerTap = false; touchStartTime = Date.now();
-            lastTouchX = e.touches[0].clientX; lastTouchY = e.touches[0].clientY;
- 
-            if (touchMode === 0) {
-                // DIRECT MODE: 1:1 Touch = Mouse Down immediately (Perfect for drag & drop)
-                const coords = getEmulatorCoords(lastTouchX, lastTouchY);
-                cursorX = coords.x; cursorY = coords.y;
-                moveMouse(cursorX, cursorY);
-                mouseButton(0, true);
-                isLeftDown = true;
-                isClickCandidate = false; // Prevent double-trigger on up
-            } else if (touchMode === 1) {
-                // TRACKPAD MODE: Hold finger down for 400ms to start a Drag-Lock
-                dragTimer = setTimeout(() => {
-                    isLeftDown = true;
-                    isClickCandidate = false;
-                    mouseButton(0, true);
-                }, 400);
-            }
-        }
-    });
- 
-    touchOverlay.addEventListener('touchmove', (e) => {
-        e.preventDefault();
-        if (e.touches.length === 2) {
-            isClickCandidate = false; 
-            const currentPinchCenterX = (e.touches[0].clientX + e.touches[1].clientX) / 2, currentPinchCenterY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-            const dist = Math.hypot(e.touches[0].clientX - e.touches[1].clientX, e.touches[0].clientY - e.touches[1].clientY);
-            if (Math.abs(dist - startDist) > 15 || Math.hypot(currentPinchCenterX - pinchCenterX, currentPinchCenterY - pinchCenterY) > 15) isTwoFingerTap = false; 
-            const maxZoom = 2.5 / cssScale, newScale = Math.min(Math.max(1, initialPzScale * (dist / startDist)), maxZoom), scaleRatio = newScale / initialPzScale;
-            pzX = currentPinchCenterX - (pinchCenterX - initialPzX) * scaleRatio; pzY = currentPinchCenterY - (pinchCenterY - initialPzY) * scaleRatio;
-            pzScale = newScale; updatePanZoom();
-            if(touchMode === 2) updatePanCursor();
-        } else if (e.touches.length === 1) {
-            const currentTouchX = e.touches[0].clientX, currentTouchY = e.touches[0].clientY;
-            const movedDist = Math.hypot(currentTouchX - lastTouchX, currentTouchY - lastTouchY);
- 
-            if (touchMode === 2) { 
-                // PAN MODE
-                isClickCandidate = false;
-                pzX += (currentTouchX - lastTouchX); pzY += (currentTouchY - lastTouchY);
-                updatePanZoom(); updatePanCursor();
-            } else if (touchMode === 1) { 
-                // TRACKPAD MODE
-                if (dragTimer && movedDist > 5) {
-                    // Finger moved too soon, cancel drag lock detection
-                    clearTimeout(dragTimer); dragTimer = null;
-                }
-                if (!isLeftDown) isClickCandidate = false; // Moving before hold means just hovering, cancel click candidate
-                
-                const dX = (currentTouchX - lastTouchX) / (cssScale * pzScale); const dY = (currentTouchY - lastTouchY) / (cssScale * pzScale);
-                cursorX = Math.max(0, Math.min(baseWidth, cursorX + (dX * 1.5))); cursorY = Math.max(0, Math.min(baseHeight, cursorY + (dY * 1.5)));
-                moveMouse(cursorX, cursorY);
-            } else if (touchMode === 0) { 
-                // DIRECT MODE
-                const coords = getEmulatorCoords(currentTouchX, currentTouchY);
-                cursorX = Math.max(0, Math.min(baseWidth, coords.x)); cursorY = Math.max(0, Math.min(baseHeight, coords.y));
-                moveMouse(cursorX, cursorY);
-            }
-            lastTouchX = currentTouchX; lastTouchY = currentTouchY;
-        }
-    });
- 
-    touchOverlay.addEventListener('touchend', (e) => {
-        e.preventDefault();
-        
+
+    function updatePanCursor() {
+        const c = getEmulatorCoords(window.innerWidth / 2, window.innerHeight / 2);
+        setCursor(c.x, c.y);
+    }
+
+    // ---- zoom ---------------------------------------------------------
+    function zoomAbout(clientX, clientY, wanted) {
+        const maxZoom = Math.max(1, 2.5 / cssScale);
+        const next = Math.min(Math.max(1, wanted), maxZoom);
+        if (next === pzScale) return;
+        const ratio = next / pzScale;
+        pzX = clientX - (clientX - pzX) * ratio;
+        pzY = clientY - (clientY - pzY) * ratio;
+        pzScale = next;
+        updatePanZoom();
+        if (touchMode === 2) updatePanCursor();
+    }
+
+    function pinchPair() { return [...pointers.values()].slice(0, 2); }
+
+    function beginPinch() {
+        const [a, b] = pinchPair();
+        if (!a || !b) return;
         if (dragTimer) { clearTimeout(dragTimer); dragTimer = null; }
- 
-        if (e.touches.length === 0) {
-            const timeElapsed = Date.now() - touchStartTime;
-            
-            if (isLeftDown) {
-                // If dragging in direct/trackpad mode, release the click
-                mouseButton(0, false);
-                isLeftDown = false;
-            } else if (isTwoFingerTap && timeElapsed < 300) {
-                // Right click
-                mouseButton(2, true);
-                setTimeout(() => mouseButton(2, false), 50);
-            } else if (isClickCandidate && timeElapsed < 300) {
-                // Quick tap for Pan or Trackpad Mode
-                if (touchMode === 2) {
-                    const coords = getEmulatorCoords(lastTouchX, lastTouchY);
-                    moveMouse(coords.x, coords.y);
-                    setTimeout(() => { mouseButton(0, true); setTimeout(() => mouseButton(0, false), 50); }, 20);
-                } else if (touchMode === 1) {
-                    mouseButton(0, true);
-                    setTimeout(() => mouseButton(0, false), 50);
-                }
-            }
+        releaseAllButtons();
+        pinchDist = Math.hypot(a.x - b.x, a.y - b.y) || 1;
+        initialPzScale = pzScale; initialPzX = pzX; initialPzY = pzY;
+        pinchCenterX = (a.x + b.x) / 2; pinchCenterY = (a.y + b.y) / 2;
+        isClickCandidate = false;
+        isTwoFingerTap = true;
+        gestureStart = Date.now();
+    }
+
+    function updatePinch() {
+        const [a, b] = pinchPair();
+        if (!a || !b) return;
+        const cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2;
+        const dist = Math.hypot(a.x - b.x, a.y - b.y);
+        if (Math.abs(dist - pinchDist) > 15 || Math.hypot(cx - pinchCenterX, cy - pinchCenterY) > 15)
             isTwoFingerTap = false;
-        }
-    });
- 
+        const maxZoom = Math.max(1, 2.5 / cssScale);
+        const next = Math.min(Math.max(1, initialPzScale * (dist / pinchDist)), maxZoom);
+        const ratio = next / initialPzScale;
+        pzX = cx - (pinchCenterX - initialPzX) * ratio;
+        pzY = cy - (pinchCenterY - initialPzY) * ratio;
+        pzScale = next;
+        updatePanZoom();
+        if (touchMode === 2) updatePanCursor();
+    }
+
     function updatePanZoom() {
-        const scaledW = window.innerWidth * pzScale; const scaledH = window.innerHeight * pzScale;
-        if (pzScale <= 1) { pzX = 0; pzY = 0; } else { pzX = Math.min(0, Math.max(pzX, window.innerWidth - scaledW)); pzY = Math.min(0, Math.max(pzY, window.innerHeight - scaledH)); }
+        const scaledW = window.innerWidth * pzScale, scaledH = window.innerHeight * pzScale;
+        if (pzScale <= 1) { pzX = 0; pzY = 0; }
+        else {
+            pzX = Math.min(0, Math.max(pzX, window.innerWidth - scaledW));
+            pzY = Math.min(0, Math.max(pzY, window.innerHeight - scaledH));
+        }
         panZoomContainer.style.transform = `translate(${pzX}px, ${pzY}px) scale(${pzScale})`;
     }
+
+    // ---- the pointers themselves ---------------------------------------
+    touchOverlay.addEventListener('pointerdown', e => {
+        e.preventDefault();
+        // Capture, so a drag that outruns the overlay -- off the edge of the
+        // window, over a floating control -- keeps arriving here.
+        touchOverlay.setPointerCapture?.(e.pointerId);
+        pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+        if (pointers.size === 2) { beginPinch(); return; }
+        if (pointers.size > 2) return;
+
+        primaryId = e.pointerId;
+        startX = lastX = e.clientX; startY = lastY = e.clientY;
+        gestureStart = Date.now();
+        isTwoFingerTap = false;
+        isClickCandidate = true;
+
+        const mode = modeFor(e);
+        if (mode === 2) { touchOverlay.classList.add('panning'); return; }
+
+        if (isPrecise(e)) {
+            // A real button, pressed where the pointer already is. The right
+            // one goes through as the right one; the two-finger tap below is
+            // how a finger says the same thing.
+            const c = getEmulatorCoords(e.clientX, e.clientY);
+            setCursor(c.x, c.y);
+            pressButton(buttonOf(e));
+            isClickCandidate = false;
+        } else if (mode === 0) {
+            // Direct: the finger is the pointer, and it presses as it lands,
+            // which is what makes dragging things around work.
+            const c = getEmulatorCoords(e.clientX, e.clientY, FINGER_OFFSET_Y);
+            setCursor(c.x, c.y);
+            pressButton(0);
+            isClickCandidate = false;
+        } else {
+            // Trackpad: hold still for 0.4s and the button locks down.
+            dragTimer = setTimeout(() => {
+                dragTimer = null; isClickCandidate = false; pressButton(0);
+            }, 400);
+        }
+    });
+
+    touchOverlay.addEventListener('pointermove', e => {
+        const p = pointers.get(e.pointerId);
+        if (!p) {
+            // A mouse with no button down still has to move the pointer inside
+            // the Mac: menus do not highlight, and Cythera's cursor never
+            // changes shape over something it can act on, without this.
+            if (isPrecise(e) && modeFor(e) !== 2) {
+                const c = getEmulatorCoords(e.clientX, e.clientY);
+                setCursor(c.x, c.y);
+            }
+            return;
+        }
+        e.preventDefault();
+        p.x = e.clientX; p.y = e.clientY;
+        if (pointers.size >= 2) { updatePinch(); return; }
+        if (e.pointerId !== primaryId) return;
+
+        const dx = e.clientX - lastX, dy = e.clientY - lastY;
+        lastX = e.clientX; lastY = e.clientY;
+        // Measured from where the gesture started, not from the last event: a
+        // slow drag never travels 8 pixels between two moves, so a tap used to
+        // be able to wander the whole screen and still count as a tap.
+        const travelled = Math.hypot(e.clientX - startX, e.clientY - startY);
+        if (travelled > TAP_SLOP) isClickCandidate = false;
+
+        const mode = modeFor(e);
+        if (mode === 2) {
+            pzX += dx; pzY += dy;
+            updatePanZoom();
+            updatePanCursor();
+        } else if (isPrecise(e) || mode === 0) {
+            const c = getEmulatorCoords(e.clientX, e.clientY, isPrecise(e) ? 0 : FINGER_OFFSET_Y);
+            setCursor(c.x, c.y);
+        } else {
+            if (dragTimer && travelled > 6) { clearTimeout(dragTimer); dragTimer = null; }
+            const k = 1.5 / (cssScale * pzScale);
+            setCursor(cursorX + dx * k, cursorY + dy * k);
+        }
+    });
+
+    function endPointer(e, cancelled) {
+        if (!pointers.delete(e.pointerId)) return;
+        if (touchOverlay.hasPointerCapture?.(e.pointerId)) touchOverlay.releasePointerCapture(e.pointerId);
+        touchOverlay.classList.remove('panning');
+
+        if (pointers.size >= 1) {
+            // One finger of a pinch lifted. Hand the gesture to what is left,
+            // so the survivor's next move continues from where it is rather
+            // than jumping by however far apart the two fingers were.
+            const [id, p] = pointers.entries().next().value;
+            primaryId = id;
+            startX = lastX = p.x; startY = lastY = p.y;
+            isClickCandidate = false;
+            if (pointers.size >= 2) beginPinch();
+            return;
+        }
+
+        if (dragTimer) { clearTimeout(dragTimer); dragTimer = null; }
+        const elapsed = Date.now() - gestureStart;
+
+        if (cancelled) {
+            releaseAllButtons();
+        } else if (heldButtons.size) {
+            // A press that has already gone through: let go of it.
+            if (isPrecise(e)) releaseButton(buttonOf(e)); else releaseAllButtons();
+        } else if (isTwoFingerTap && elapsed < TAP_MS) {
+            clickOnce(2);
+        } else if (isClickCandidate && elapsed < TAP_MS) {
+            if (modeFor(e) === 2) {
+                // Pan View: tap where you meant, and click there.
+                const c = getEmulatorCoords(e.clientX, e.clientY, isPrecise(e) ? 0 : FINGER_OFFSET_Y);
+                setCursor(c.x, c.y);
+                setTimeout(() => clickOnce(0), 20);
+            } else {
+                clickOnce(0);
+            }
+        }
+        isTwoFingerTap = false;
+        isClickCandidate = false;
+        primaryId = null;
+    }
+    touchOverlay.addEventListener('pointerup', e => endPointer(e, false));
+    touchOverlay.addEventListener('pointercancel', e => endPointer(e, true));
+
+    // Nothing in the embed API carries a scroll wheel through to the emulated
+    // Mac, so the wheel is free to be the desktop half of the pinch.
+    touchOverlay.addEventListener('wheel', e => {
+        e.preventDefault();
+        const step = e.deltaMode === 1 ? e.deltaY * 16 : e.deltaMode === 2 ? e.deltaY * 400 : e.deltaY;
+        zoomAbout(e.clientX, e.clientY, pzScale * Math.exp(-step * 0.002));
+    }, { passive: false });
+
+    // The right button belongs to the emulated Mac, not to the browser.
+    touchOverlay.addEventListener('contextmenu', e => e.preventDefault());
+
+    /* ---- A real keyboard -------------------------------------------------
+       The emulator is in a cross-origin iframe with #touch-overlay on top of
+       it, so it can never take the keyboard focus: on a desktop this page had
+       no keyboard at all beyond the on-screen buttons, and Cythera is a game
+       played on the numeric keypad.
+
+       Keys go through by `code`, which names the physical key, so a Dvorak or
+       AZERTY layout arrives as the key the emulator's own table knows. A code
+       it does not recognise it ignores. */
+    const BROWSER_OWNS = new Set(['F5', 'F11', 'F12']);
+    function keyboardGoesToEmulator(e) {
+        if (!hudLayer.classList.contains('active')) return false;   // not started yet
+        if (!helpPanel.hidden || !modalEl.hidden) return false;
+        const t = e.target;
+        if (!t) return true;
+        if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable) return false;
+        // A focused on-screen control handles its own Enter and Space; without
+        // this, pressing one would also send the key straight to the Mac.
+        if (t.closest && t.closest('#hud-layer')) return false;
+        return true;
+    }
+    function browserKeepsKey(e) {
+        if (BROWSER_OWNS.has(e.key)) return true;
+        // Reload, new tab, close, address bar: the browser acts on these
+        // whatever this page asks for, and forwarding one only leaves a
+        // modifier stuck down inside the emulated Mac.
+        return (e.ctrlKey || e.metaKey) && /^Key[RTWNLQ]$/.test(e.code);
+    }
+    document.addEventListener('keydown', e => {
+        if (!keyboardGoesToEmulator(e) || browserKeepsKey(e)) return;
+        e.preventDefault();          // no page scrolling on Space or the arrows
+        if (e.repeat || !e.code) return;   // the Mac does its own repeating
+        pressKey(e.code);
+    });
+    const isModifierCode = code => /^(Meta|Control|Alt|Shift)/.test(code);
+    document.addEventListener('keyup', e => {
+        if (!keyboardGoesToEmulator(e) || !e.code) return;
+        releaseKey(e.code);
+        // macOS does not deliver keyup for a non-modifier key pressed while
+        // Command is held (mihaip/infinite-mac#89), so the emulated Mac is
+        // left holding it down. Infinite Mac works around this for its own
+        // keyboard; keys sent through the embed API arrive past that, so the
+        // same sweep has to happen here. Releasing a key that is already up
+        // costs nothing, which is why this is not conditional on the platform.
+        if (e.code.startsWith('Meta')) {
+            for (const code of Array.from(heldKeys)) {
+                if (!isModifierCode(code)) releaseKey(code);
+            }
+        }
+    });
 
     /* ---- Dropping a file on the emulator --------------------------------
        Infinite Mac already accepts dropped files: a disk image is mounted,

--- a/cythera/mobile.html
+++ b/cythera/mobile.html
@@ -82,6 +82,10 @@
             z-index: 100; opacity: 0; transition: opacity 0.5s ease-in;
         }
         #hud-layer.active { opacity: 1; }
+        /* With a keyboard and a mouse the two floating windows are in the way
+           rather than in use. The settings panel stays: it is what brings
+           them back. */
+        #hud-layer.controls-hidden .hud-window { display: none; }
  
         .hud-window {
             position: absolute; pointer-events: auto; background-color: rgba(59, 0, 0, 0.85); 
@@ -121,10 +125,20 @@
  
         #settings-drawer {
             position: absolute; bottom: 0; left: 50%; transform: translateX(-50%); background: rgba(59, 0, 0, 0.95); border: 2px solid #8B6914; border-bottom: none;
-            border-radius: 12px 12px 0 0; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); z-index: 1000; width: 90%; max-width: 450px; backdrop-filter: blur(4px); pointer-events: auto;
+            /* No transition on `transform`: it existed to animate the slide off
+               the bottom edge, and collapsing no longer moves the panel. Left
+               in place it animated the un-centring as the panel was picked up,
+               so for 300ms the panel was somewhere neither the pointer nor the
+               code thought it was. */
+            border-radius: 12px 12px 0 0; z-index: 1000; width: 90%; max-width: 450px; backdrop-filter: blur(4px); pointer-events: auto;
         }
-        #settings-drawer.collapsed { transform: translate(-50%, calc(100% - 28px)); }
-        .settings-handle { height: 28px; color: #FCE688; display: flex; justify-content: center; align-items: center; font-weight: bold; font-size: 0.8rem; cursor: pointer; border-bottom: 1px solid rgba(196, 164, 100, 0.3); }
+        /* Collapsing hides the buttons where the panel stands. It used to slide
+           the panel off the bottom edge, which stops meaning anything once the
+           panel can be anywhere. */
+        #settings-drawer.collapsed .settings-content { display: none; }
+        #settings-drawer.collapsed .settings-handle { border-bottom: none; }
+        .settings-handle { height: 28px; color: #FCE688; display: flex; justify-content: center; align-items: center; font-weight: bold; font-size: 0.8rem; cursor: move; border-bottom: 1px solid rgba(196, 164, 100, 0.3); touch-action: none; }
+        .settings-handle::before { content: '≡ '; opacity: 0.7; }
         .settings-content { display: flex; flex-wrap: wrap; justify-content: space-around; padding: 10px; gap: 8px; }
         .settings-btn { flex: 1 1 30%; padding: 8px 0; font-size: 0.7rem; height: auto; }
  
@@ -262,6 +276,8 @@
                      actually do. -->
                 <div class="btn settings-btn" id="fullscreen-btn"><span class="emoji">⛶</span>Full</div>
                 <div class="btn settings-btn" id="disk-btn"><span class="emoji">💿</span>Disk</div>
+                <div class="btn settings-btn" id="controls-btn"><span class="emoji">🎮</span>Pads</div>
+                <div class="btn settings-btn" id="reset-layout-btn"><span class="emoji">↺</span>Reset</div>
                 <div class="btn settings-btn" id="help-btn"><span class="emoji">❔</span>Help</div>
             </div>
         </div>
@@ -276,7 +292,11 @@
             <h3>Moving and acting</h3>
             <p>The two floating windows are the numeric keypad and Cythera's action keys. Drag a
             window by its <b>≡</b> header, resize it from the corner, or press <b>Gestures</b> in
-            its header to swap the buttons for a thumb control.</p>
+            its header to swap the buttons for a thumb control. The settings panel moves the same
+            way — drag its <b>≡</b> bar to put it somewhere it is not in the way, or tap the bar
+            to fold it down to a strip. <b>Pads</b> hides both floating windows, which is what you
+            want once you are using a keyboard; <b>Reset</b> puts everything back where it started.
+            Where you leave them is remembered on this device.</p>
             <ul id="gesture-legend"></ul>
 
             <h3>Touching the screen</h3>
@@ -480,9 +500,13 @@
         // A click to wake the emulated Mac up. It has to happen *somewhere*,
         // and with no move first that somewhere is 0,0 -- the corner of the
         // menu bar, so starting the game pulled down the Apple menu.
+        // Through the outbox, not posted raw: it is what puts the move ahead
+        // of the press and keeps the press and its release in separate sync
+        // windows. Posting these directly would race the queued move and put
+        // the click back at 0,0.
         setCursor(screenWidth / 2, screenHeight / 2);
-        post({ type: 'emulator_mouse_down', button: 0 });
-        post({ type: 'emulator_mouse_up', button: 0 });
+        mouseButton(0, true);
+        mouseButton(0, false);
         touchOverlay.classList.add('active');
         hudLayer.classList.add('active');
     }
@@ -554,16 +578,90 @@
     // machines that are relative-only (Previous, DingusPPC, PearPC) read
     // nothing else. Sending both costs two properties and means ?machine=
     // can point at one of those without the pointer going dead.
+    /* Everything this page sends between two of the emulator's input syncs is
+       collapsed into ONE state before the emulated Mac ever sees it. From
+       updateInputBufferWithEvents() in the emulator's own common.ts: the FIRST
+       mousemove of a batch is kept and every later one is dropped, and each
+       mousedown/mouseup overwrites the last, because what reaches the Mac is a
+       button LEVEL and not an edge.
+
+       Two things follow, and both were happening:
+
+         a press and the release after it, inside one window, cancel out --
+         the level never changes and the click simply does not happen;
+
+         a release and the NEXT press, inside one window, lose the release --
+         the level stays down, so the Mac believes the button has been held
+         since the previous tap and the cursor arriving somewhere else is a
+         DRAG from there to here.
+
+       That is why Direct mode dragged in random directions on a tap: it is
+       the one mode that presses on touch-down and releases on touch-up with
+       nothing in between, so both collapses were live. The other modes went
+       through clickOnce(), whose 50ms straddled a sync window by luck.
+
+       So button transitions are spaced out in time here, and every transition
+       carries the position with it. There is no batch a transition can share
+       with its own opposite. */
+    /* How long a button level has to stand before the opposite one may be
+       sent. It has to outlast the emulator's input window, and that window is
+       not fixed -- input is consumed when the guest next polls, so a busy
+       machine has a longer one. 70ms covers a window of up to 50ms (a guest
+       polling at 20Hz); past that a physical mouse click would be swallowed
+       too, so the machine is not usable at that point anyway.
+
+       It costs nothing that can be felt: a press is sent the moment it
+       happens, and only the release waits. */
+    const BUTTON_GAP_MS = 70;
     let lastSentX = null, lastSentY = null;
-    function moveMouse(x, y) {
-        const rx = Math.round(x), ry = Math.round(y);
+    let pendingMove = null, moveFrame = null;
+    const buttonOutbox = [];
+    let buttonTimer = null, lastButtonAt = 0;
+
+    function sendMove() {
+        if (moveFrame !== null) { cancelAnimationFrame(moveFrame); moveFrame = null; }
+        if (!pendingMove) return;
+        const rx = Math.round(pendingMove.x), ry = Math.round(pendingMove.y);
+        pendingMove = null;
+        // emulator_mouse_move carries an absolute position *and* a delta.
+        // Basilisk II -- the Quadra 650's emulator -- reads the absolute pair,
+        // which is why sending only x/y worked, but the deltas are part of the
+        // message and the machines that are relative-only (Previous,
+        // DingusPPC, PearPC) read nothing else.
         const deltaX = lastSentX === null ? 0 : rx - lastSentX;
         const deltaY = lastSentY === null ? 0 : ry - lastSentY;
         lastSentX = rx; lastSentY = ry;
         post({ type: 'emulator_mouse_move', x: rx, y: ry, deltaX: deltaX, deltaY: deltaY });
     }
+
+    function moveMouse(x, y) {
+        pendingMove = {x: x, y: y};
+        // A button transition flushes the position itself, in order, so that
+        // the press lands where the pointer actually is.
+        if (buttonOutbox.length) return;
+        // One move per frame, carrying the newest position. Sending every
+        // pointermove only fed the emulator more than it keeps -- and what it
+        // keeps is the OLDEST of the batch, so the cursor trailed the finger.
+        if (moveFrame === null) moveFrame = requestAnimationFrame(() => { moveFrame = null; sendMove(); });
+    }
+
     function mouseButton(button, down) {
-        post({ type: down ? 'emulator_mouse_down' : 'emulator_mouse_up', button: button });
+        buttonOutbox.push({button: button, down: down});
+        pumpButtons();
+    }
+
+    function pumpButtons() {
+        if (buttonTimer !== null || !buttonOutbox.length) return;
+        const wait = BUTTON_GAP_MS - (Date.now() - lastButtonAt);
+        if (wait > 0) {
+            buttonTimer = setTimeout(() => { buttonTimer = null; pumpButtons(); }, wait);
+            return;
+        }
+        const next = buttonOutbox.shift();
+        sendMove();     // first in the batch, so the press lands on target
+        post({ type: next.down ? 'emulator_mouse_down' : 'emulator_mouse_up', button: next.button });
+        lastButtonAt = Date.now();
+        if (buttonOutbox.length) pumpButtons();
     }
 
     // Every key this page can send, so that a key held when the page is hidden
@@ -605,27 +703,7 @@
         const toggleBtn = win.querySelector('.mode-toggle'), btnGrid = win.querySelector('.btn-grid'), gestureArea = win.querySelector('.gesture-area');
         hudWindows.push(win);
 
-        let dragId = null, dragStartX = 0, dragStartY = 0, initialLeft = 0, initialTop = 0;
-        dragHandle.addEventListener('pointerdown', e => {
-            e.preventDefault(); e.stopPropagation();
-            dragId = e.pointerId;
-            dragHandle.setPointerCapture?.(e.pointerId);
-            dragStartX = e.clientX; dragStartY = e.clientY;
-            const rect = win.getBoundingClientRect(); initialLeft = rect.left; initialTop = rect.top;
-            win.style.zIndex = 200;
-        });
-        dragHandle.addEventListener('pointermove', e => {
-            if (dragId !== e.pointerId) return;
-            e.preventDefault();
-            placeWindow(win, initialLeft + (e.clientX - dragStartX), initialTop + (e.clientY - dragStartY));
-        });
-        const endDrag = e => {
-            if (dragId !== e.pointerId) return;
-            dragId = null; win.style.zIndex = '';
-            saveHudLayout();
-        };
-        dragHandle.addEventListener('pointerup', endDrag);
-        dragHandle.addEventListener('pointercancel', endDrag);
+        makeDraggable(win, dragHandle, {onEnd: saveHudLayout});
 
         let resizeId = null, resizeStartX = 0, resizeStartY = 0, initialWidth = 0, initialHeight = 0;
         resizeHandle.addEventListener('pointerdown', e => {
@@ -656,6 +734,42 @@
         });
     });
 
+    /* Dragging, for anything with a grab handle. The settings panel wants the
+       same behaviour as the floating windows, and it also has to keep working
+       as a button -- so a press that never travels more than a few pixels is
+       reported as a tap instead of a move. */
+    function makeDraggable(el, handle, opts) {
+        const options = opts || {};
+        let id = null, fromX = 0, fromY = 0, originLeft = 0, originTop = 0, travelled = false;
+        handle.addEventListener('pointerdown', e => {
+            e.preventDefault(); e.stopPropagation();
+            id = e.pointerId;
+            handle.setPointerCapture?.(e.pointerId);
+            fromX = e.clientX; fromY = e.clientY;
+            const rect = el.getBoundingClientRect();
+            originLeft = rect.left; originTop = rect.top;
+            travelled = false;
+            el.style.zIndex = 200;
+        });
+        handle.addEventListener('pointermove', e => {
+            if (id !== e.pointerId) return;
+            e.preventDefault();
+            const dx = e.clientX - fromX, dy = e.clientY - fromY;
+            if (!travelled && Math.hypot(dx, dy) <= 5) return;
+            travelled = true;
+            placeWindow(el, originLeft + dx, originTop + dy);
+        });
+        const end = e => {
+            if (id !== e.pointerId) return;
+            id = null;
+            el.style.zIndex = '';
+            if (travelled) { if (options.onEnd) options.onEnd(); }
+            else if (options.onTap) options.onTap();
+        };
+        handle.addEventListener('pointerup', end);
+        handle.addEventListener('pointercancel', end);
+    }
+
     function setWindowMode(win, gestures) {
         const btnGrid = win.querySelector('.btn-grid'), gestureArea = win.querySelector('.gesture-area');
         const toggleBtn = win.querySelector('.mode-toggle');
@@ -679,10 +793,19 @@
         const y = Math.max(0, Math.min(window.innerHeight - Math.min(h, window.innerHeight), top));
         win.style.left = `${x}px`; win.style.top = `${y}px`;
         win.style.bottom = 'auto'; win.style.right = 'auto';
+        // The settings panel is centred with a transform until it is moved.
+        win.style.transform = 'none';
     }
 
     function saveHudLayout() {
         const layout = {};
+        const drawer = document.getElementById('settings-drawer');
+        if (drawer && drawer.style.left) {
+            const r = drawer.getBoundingClientRect();
+            layout.drawer = {left: Math.round(r.left), top: Math.round(r.top)};
+        }
+        layout.drawerCollapsed = drawer ? drawer.classList.contains('collapsed') : true;
+        layout.controlsHidden = hudLayer.classList.contains('controls-hidden');
         for (const win of hudWindows) {
             const r = win.getBoundingClientRect();
             layout[win.id] = {
@@ -697,6 +820,12 @@
     function restoreHudLayout() {
         const layout = loadPrefs().hud;
         if (!layout) return;
+        const drawer = document.getElementById('settings-drawer');
+        if (drawer) {
+            drawer.classList.toggle('collapsed', layout.drawerCollapsed !== false);
+            if (layout.drawer) placeWindow(drawer, layout.drawer.left, layout.drawer.top);
+        }
+        if (layout.controlsHidden) setControlsHidden(true);
         for (const win of hudWindows) {
             const s = layout[win.id];
             if (!s) continue;
@@ -843,7 +972,7 @@
             }
         }
         const hit = recogniseGesture(dirs, totalDist < 15 && gesturePoints.length < 10);
-        if (hit) { showToast(hit.name); pressKey(hit.key); setTimeout(() => releaseKey(hit.key), 50); }
+        if (hit) { showToast(hit.name); pressKey(hit.key); setTimeout(() => releaseKey(hit.key), 50); }   // keys are queued by the emulator, not collapsed
         else { showToast("?"); }
     });
  
@@ -1156,8 +1285,26 @@
     }
 
     // Settings Drawer Buttons
-    onTap(document.getElementById('settings-handle'),
-          () => document.getElementById('settings-drawer').classList.toggle('collapsed'));
+    /* The settings panel used to be bolted to the bottom of the screen, where
+       it sat on top of whatever was there -- and on a phone in landscape that
+       is most of the game. It moves now, like the other floating windows, and
+       collapsing it hides its buttons where it stands rather than sliding it
+       off the bottom edge, which would be meaningless once it has been moved.
+
+       Its handle is both the grab bar and the collapse button: a press that
+       goes nowhere toggles, a press that travels moves it. */
+    const settingsDrawer = document.getElementById('settings-drawer');
+    const settingsHandle = document.getElementById('settings-handle');
+    function toggleSettings() {
+        settingsDrawer.classList.toggle('collapsed');
+        saveHudLayout();
+    }
+    makeDraggable(settingsDrawer, settingsHandle, {onTap: toggleSettings, onEnd: saveHudLayout});
+    settingsHandle.tabIndex = 0;
+    settingsHandle.setAttribute('role', 'button');
+    settingsHandle.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleSettings(); }
+    });
  
     let touchMode = 0;
     const touchModeToggle = document.getElementById('touch-mode-toggle');
@@ -1272,6 +1419,37 @@
             }, config.cdrom);
     });
 
+    const controlsBtn = document.getElementById('controls-btn');
+    function setControlsHidden(hidden) {
+        hudLayer.classList.toggle('controls-hidden', hidden);
+        controlsBtn.innerHTML = hidden ? '<span class="emoji">🎮</span>Pads off'
+                                       : '<span class="emoji">🎮</span>Pads';
+        // Whatever a hidden pad was holding down, it is not holding it now.
+        if (hidden) { stopMovement(); releaseAllKeys(); }
+    }
+    onTap(controlsBtn, () => {
+        setControlsHidden(!hudLayer.classList.contains('controls-hidden'));
+        saveHudLayout();
+    });
+
+    // Windows can be dragged somewhere unhelpful, and a layout saved on a
+    // phone makes no sense on a desktop. This is the way back.
+    onTap(document.getElementById('reset-layout-btn'), () => {
+        askConfirm('Put the floating windows and the settings panel back where they started?', () => {
+            savePrefs({hud: null});
+            for (const win of hudWindows) {
+                win.style.left = win.style.top = win.style.right = win.style.bottom = '';
+                win.style.width = win.style.height = '';
+                setWindowMode(win, false);
+            }
+            settingsDrawer.style.left = settingsDrawer.style.top = '';
+            settingsDrawer.style.transform = '';
+            settingsDrawer.classList.add('collapsed');
+            setControlsHidden(false);
+            showToast('Layout reset');
+        });
+    });
+
     const helpPanel = document.getElementById('help-panel');
     onTap(document.getElementById('help-btn'), () => { helpPanel.hidden = false; });
     onTap(document.getElementById('help-close'), () => { helpPanel.hidden = true; });
@@ -1354,7 +1532,9 @@
     function pressButton(b) { if (!heldButtons.has(b)) { heldButtons.add(b); mouseButton(b, true); } }
     function releaseButton(b) { if (heldButtons.delete(b)) mouseButton(b, false); }
     function releaseAllButtons() { for (const b of Array.from(heldButtons)) releaseButton(b); }
-    function clickOnce(button) { pressButton(button); setTimeout(() => releaseButton(button), 50); }
+    // The outbox below guarantees the press and the release reach the Mac as
+    // two separate levels, so a click no longer has to time its own release.
+    function clickOnce(button) { pressButton(button); releaseButton(button); }
     const buttonOf = e => (e.button === 2 ? 2 : e.button === 1 ? 1 : 0);
 
     function getEmulatorCoords(clientX, clientY, offsetY) {
@@ -1549,7 +1729,7 @@
                 // Pan View: tap where you meant, and click there.
                 const c = getEmulatorCoords(e.clientX, e.clientY, isPrecise(e) ? 0 : FINGER_OFFSET_Y);
                 setCursor(c.x, c.y);
-                setTimeout(() => clickOnce(0), 20);
+                clickOnce(0);
             } else {
                 clickOnce(0);
             }
@@ -1697,6 +1877,11 @@
         for (const win of hudWindows) {
             const r = win.getBoundingClientRect();
             placeWindow(win, r.left, r.top);
+        }
+        // Only once it has been moved: until then its own CSS centres it.
+        if (settingsDrawer.style.left) {
+            const r = settingsDrawer.getBoundingClientRect();
+            placeWindow(settingsDrawer, r.left, r.top);
         }
     });
 </script>

--- a/cythera/mobile.html
+++ b/cythera/mobile.html
@@ -298,6 +298,14 @@
             <code>F11</code>, <code>F12</code> and its own reload/new-tab/close shortcuts.
             Everything on this page can also be reached with Tab and Enter.</p>
 
+            <h3>The picture</h3>
+            <p><b>Crisp</b> shows the emulator's own pixels, unaltered. <b>Undith</b> runs the
+            same undither <a href="cythera_data_viewer.html">the data viewer</a> uses on the
+            game's artwork. Mac OS draws a shade it has no palette entry for as a checkerboard
+            of two colours it does have; this reads that pattern back as the tone it was
+            standing in for, and can tell it apart from linework, so a one-pixel highlight
+            survives where a blur would have taken it. It needs WebGL.</p>
+
             <h3>Loading your own Cythera</h3>
             <p><b>Drag a file onto the emulator</b> — a disk image (<code>.dsk</code>,
             <code>.img</code>, <code>.iso</code>) mounts, and anything else, including the
@@ -407,7 +415,7 @@
         // the TAP TO START overlay, and the emulator_unpause sent on tap was
         // unpausing something that had never been paused.
         u.searchParams.set('paused', 'true');
-        // The de-dither filter needs the frames, and the frames are also the
+        // The undither needs the frames, and the frames are also the
         // only place the emulator states the resolution it actually came up
         // with. They are not free: a whole screen is copied across origins on
         // every drawn frame. The parameter is read once at boot, so switching
@@ -509,7 +517,7 @@
         scaleTarget.style.width = `${w}px`;
         scaleTarget.style.height = `${h}px`;
         glCanvas.width = w; glCanvas.height = h;
-        if (shaderReady && texSizeLocation) gl.uniform2f(texSizeLocation, w, h);
+        setSize(w, h);
         setCursor(cursorX, cursorY);
         applyCssScale();
     }
@@ -839,26 +847,170 @@
         else { showToast("?"); }
     });
  
-    // Smart Shader
-    const gl = glCanvas.getContext('webgl', { alpha: false, antialias: false });
-    const vsSource = `attribute vec2 a_position; varying vec2 v_texCoord; void main() { v_texCoord = a_position * 0.5 + 0.5; v_texCoord.y = 1.0 - v_texCoord.y; gl_Position = vec4(a_position, 0.0, 1.0); }`;
-    const fsSource = `
-        precision mediump float; varying vec2 v_texCoord; uniform sampler2D u_image; uniform vec2 u_texSize;
+    /* ---- Undither -------------------------------------------------------
+       The same filter cythera_data_viewer.html runs over the game's artwork,
+       moved onto the GPU so it can run on a live screen.
+
+       Its settings are the viewer's, and the viewer is the source of truth:
+       sensitivity 0.67, strength 67%, detail recovery 50%, the checkerboard
+       notch smoother. utilities/mobile_undither_check.mjs reads them back out
+       of the viewer and fails if the two drift apart.
+
+       The viewer's implementation could not be used as it stands. It is
+       written for one still picture with a 400-entry cache, and it costs 5.8
+       seconds for a 640x480 frame and 16 seconds at phone resolution -- five
+       orders of magnitude off a live emulator. What is here is the same
+       algorithm, stage for stage, as three full-screen passes:
+
+         1  mean    a 3x3 box mean of the frame
+         2  detect  how dithered each pixel is, and the blend
+         3  detail  re-sharpen what the blend softened
+
+       Two stages of the viewer's pipeline are deliberately not here. Stray
+       colour repair looks for isolated pixels whose HUE is wrong -- palette
+       quantisation accidents in the artwork, which an emulator's framebuffer
+       does not have. The 2x guided upscale-and-supersample buys tonal depth
+       by inventing sub-pixel samples, at four times the pixels, and the
+       viewer then pulls undithered pixels back off it again by (1-w); on a
+       screen that is already being scaled to fit, it is not worth a frame's
+       budget. `passes: 3` is not here either, because it does nothing: the
+       notch smoother reads `src`, which does not change between passes, so
+       the viewer computes the same result three times.
+
+       The old filter was a 3x3 box blur that fired only where all four
+       neighbours differed -- the same shape as the one the viewer deleted for
+       "pushing pixels off the palette". This one decides pixel by pixel
+       whether it is looking at a dither or at drawn linework, and leaves the
+       linework alone. */
+    const UNDITHER = {sens: 0.67, strength: 0.67, detail: 0.5};
+
+    const gl = glCanvas.getContext('webgl', {alpha: false, antialias: false, depth: false});
+
+    const VS = `attribute vec2 a_position; varying vec2 v_texCoord;
+        void main() { v_texCoord = a_position * 0.5 + 0.5; gl_Position = vec4(a_position, 0.0, 1.0); }`;
+
+    // A frame arrives top row first; the emulator's screen is drawn the same
+    // way, so only the pass that reaches the display flips it.
+    // CLAMP_TO_EDGE would repeat the edge pixel into the average; the viewer
+    // leaves an out-of-range neighbour out of the count instead. `inside()` is
+    // that rule, and it is what makes the two agree at the border as well as
+    // in the middle.
+    const GLSL_INSIDE = `bool inside(vec2 uv) { return uv.x >= 0.0 && uv.x <= 1.0 && uv.y >= 0.0 && uv.y <= 1.0; }`;
+
+    const FS_MEAN = `precision highp float;
+        varying vec2 v_texCoord; uniform sampler2D u_src; uniform vec2 u_texSize;
+        ${GLSL_INSIDE}
         void main() {
-            vec2 px = vec2(1.0, 1.0) / u_texSize; vec4 C = texture2D(u_image, v_texCoord);
-            vec4 L = texture2D(u_image, v_texCoord + vec2(-px.x, 0.0)); vec4 R = texture2D(u_image, v_texCoord + vec2(px.x, 0.0));
-            vec4 U = texture2D(u_image, v_texCoord + vec2(0.0, -px.y)); vec4 D = texture2D(u_image, v_texCoord + vec2(0.0, px.y));
-            float thresh = 0.08; bool diffL = distance(C.rgb, L.rgb) > thresh; bool diffR = distance(C.rgb, R.rgb) > thresh; bool diffU = distance(C.rgb, U.rgb) > thresh; bool diffD = distance(C.rgb, D.rgb) > thresh;
-            if (diffL && diffR && diffU && diffD) { gl_FragColor = (C + L + R + U + D) / 5.0; } else { gl_FragColor = C; }
-        }
-    `;
-    // The whole block below used to run unguarded at the top level, so on any
-    // browser without WebGL -- or with it blocked, or with too many live
-    // contexts -- getContext returned null and gl.createProgram() threw before
-    // the script had installed a single touch handler. The page came up as a
-    // dead emulator with no controls at all. A de-dithering filter is a nicety;
-    // it must not be able to take the page down with it.
-    let texture = null, shaderProgram = null, texSizeLocation = null;
+            vec2 px = 1.0 / u_texSize;
+            vec3 sum = vec3(0.0); float cnt = 0.0;
+            for (int dy = -1; dy <= 1; dy++)
+                for (int dx = -1; dx <= 1; dx++) {
+                    vec2 uv = v_texCoord + vec2(float(dx), float(dy)) * px;
+                    if (!inside(uv)) continue;
+                    sum += texture2D(u_src, uv).rgb; cnt += 1.0;
+                }
+            gl_FragColor = vec4(sum / cnt, 1.0);
+        }`;
+
+    /* detect(), the lock pass and the notch, in one. The residual of a pixel
+       is what is left after its own neighbourhood's mean is taken away, and
+       the question the detector asks is whether the residuals along a line
+       through the pixel agree with it or alternate against it. A dither
+       alternates; a drawn edge agrees. That is the whole idea, and it is why
+       this can smooth a checkerboard without touching a one-pixel highlight. */
+    const FS_DETECT = `precision highp float;
+        varying vec2 v_texCoord;
+        uniform sampler2D u_src; uniform sampler2D u_mean;
+        uniform vec2 u_texSize; uniform float u_sens; uniform float u_strength;
+        ${GLSL_INSIDE}
+
+        vec3 srcAt(vec2 uv) { return texture2D(u_src, uv).rgb * 255.0; }
+        vec3 resAt(vec2 uv) { return (texture2D(u_src, uv).rgb - texture2D(u_mean, uv).rgb) * 255.0; }
+
+        void main() {
+            vec2 px = 1.0 / u_texSize;
+            vec3 c = srcAt(v_texCoord);
+            vec3 r0 = resAt(v_texCoord);
+            float m = length(r0);
+            float d = 0.0;
+
+            if (m >= 0.5) {
+                float best = -2.0;
+                for (int a = 0; a < 2; a++) {
+                    vec2 ax = a == 0 ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+                    float sum = 0.0, cnt = 0.0;
+                    for (int k = 1; k <= 3; k++) {
+                        for (int sg = 0; sg < 2; sg++) {
+                            vec2 uv = v_texCoord + ax * float(k) * (sg == 0 ? -1.0 : 1.0) * px;
+                            if (!inside(uv)) continue;
+                            cnt += 1.0;
+                            vec3 rj = resAt(uv);
+                            float mj = length(rj);
+                            if (mj < 0.5) continue;      // a flat neighbour votes neutral
+                            sum += dot(r0, rj) / (m * mj);
+                        }
+                    }
+                    if (cnt > 0.0) best = max(best, sum / cnt);
+                }
+                float coh = best < -1.0 ? 1.0 : best;    // no support at all: coherent
+                d = clamp((u_sens - coh) * 8.0, 0.0, 1.0) * smoothstep(1.5, 5.0, m);
+            }
+
+            // A pixel whose whole neighbourhood is one colour has nothing to
+            // undither, whatever the residuals said.
+            bool uniformArea = true;                 // "flat" is a reserved word
+            for (int dy = -1; dy <= 1; dy++)
+                for (int dx = -1; dx <= 1; dx++) {
+                    if (dx == 0 && dy == 0) continue;
+                    vec2 uv = v_texCoord + vec2(float(dx), float(dy)) * px;
+                    if (inside(uv) && srcAt(uv) != c) uniformArea = false;
+                }
+            if (uniformArea) d = 0.0;
+
+            // The checkerboard notch: half the pixel, half its four orthogonal
+            // neighbours. It removes one frequency and leaves the rest alone.
+            vec3 n4 = vec3(0.0); float n4cnt = 0.0;
+            for (int e = 0; e < 4; e++) {
+                vec2 off = e == 0 ? vec2(px.x, 0.0) : e == 1 ? vec2(-px.x, 0.0)
+                         : e == 2 ? vec2(0.0, px.y) : vec2(0.0, -px.y);
+                vec2 uv = v_texCoord + off;
+                if (!inside(uv)) continue;
+                n4 += srcAt(uv); n4cnt += 1.0;
+            }
+            vec3 filt = n4cnt > 0.0 ? 0.5 * c + 0.5 * (n4 / n4cnt) : c;
+
+            vec3 res = c + d * u_strength * (filt - c);
+            gl_FragColor = vec4(res / 255.0, d);   // d rides along for pass 3
+        }`;
+
+    const FS_DETAIL = `precision highp float;
+        varying vec2 v_texCoord; uniform sampler2D u_res;
+        uniform vec2 u_texSize; uniform float u_strength; uniform float u_detail;
+        ${GLSL_INSIDE}
+        void main() {
+            vec2 uv = vec2(v_texCoord.x, 1.0 - v_texCoord.y);   // to the display
+            vec2 px = 1.0 / u_texSize;
+            vec4 self = texture2D(u_res, uv);
+            vec3 sum = vec3(0.0); float cnt = 0.0;
+            for (int dy = -1; dy <= 1; dy++)
+                for (int dx = -1; dx <= 1; dx++) {
+                    vec2 t = uv + vec2(float(dx), float(dy)) * px;
+                    if (!inside(t)) continue;
+                    sum += texture2D(u_res, t).rgb; cnt += 1.0;
+                }
+            vec3 blurred = sum / cnt;
+            float w = self.a * u_strength * u_detail;
+            gl_FragColor = vec4(self.rgb + w * (self.rgb - blurred), 1.0);
+        }`;
+
+    /* All of this used to run unguarded at the top level, so on a browser
+       without WebGL -- or with it blocked, or with too many live contexts --
+       getContext returned null and the script died before it had installed a
+       single input handler. The page came up as a dead emulator with no
+       controls at all. A display filter must not be able to do that. */
+    let texSrc = null, texMean = null, texRes = null, fboMean = null, fboRes = null;
+    let progMean = null, progDetect = null, progDetail = null, fboType = null;
+
     const shaderReady = (() => {
         if (!gl) return false;
         try {
@@ -870,30 +1022,100 @@
                     throw new Error(gl.getShaderInfoLog(shader) || 'shader compile failed');
                 return shader;
             };
-            shaderProgram = gl.createProgram();
-            gl.attachShader(shaderProgram, compile(gl.VERTEX_SHADER, vsSource));
-            gl.attachShader(shaderProgram, compile(gl.FRAGMENT_SHADER, fsSource));
-            gl.linkProgram(shaderProgram);
-            if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS))
-                throw new Error(gl.getProgramInfoLog(shaderProgram) || 'program link failed');
-            gl.useProgram(shaderProgram);
-            const positionBuffer = gl.createBuffer(); gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer); gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, -1,1, 1,-1, 1,1]), gl.STATIC_DRAW);
-            const positionLocation = gl.getAttribLocation(shaderProgram, "a_position"); gl.enableVertexAttribArray(positionLocation); gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
-            texture = gl.createTexture(); gl.bindTexture(gl.TEXTURE_2D, texture); gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST); gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST); gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE); gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-            texSizeLocation = gl.getUniformLocation(shaderProgram, "u_texSize"); gl.uniform2f(texSizeLocation, screenWidth, screenHeight);
+            const link = fs => {
+                const prog = gl.createProgram();
+                gl.attachShader(prog, compile(gl.VERTEX_SHADER, VS));
+                gl.attachShader(prog, compile(gl.FRAGMENT_SHADER, fs));
+                gl.bindAttribLocation(prog, 0, 'a_position');
+                gl.linkProgram(prog);
+                if (!gl.getProgramParameter(prog, gl.LINK_STATUS))
+                    throw new Error(gl.getProgramInfoLog(prog) || 'program link failed');
+                return prog;
+            };
+            progMean = link(FS_MEAN);
+            progDetect = link(FS_DETECT);
+            progDetail = link(FS_DETAIL);
+
+            const buffer = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+            gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, -1,1, 1,-1, 1,1]), gl.STATIC_DRAW);
+            gl.enableVertexAttribArray(0);
+            gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+            // The detector works on residuals -- a pixel minus its own
+            // neighbourhood's mean -- which are small numbers. Eight bits per
+            // channel quantises the mean, and the error lands squarely on the
+            // faint end of the detector's ramp, so half floats are worth
+            // asking for. Every desktop and nearly every phone GPU has them;
+            // where they are missing the filter still runs, a little coarser.
+            gl.getExtension('OES_texture_half_float_linear');
+            const halfFloat = gl.getExtension('OES_texture_half_float');
+            fboType = halfFloat ? halfFloat.HALF_FLOAT_OES : gl.UNSIGNED_BYTE;
+
+            texSrc = makeTexture();
+            texMean = makeTexture();
+            texRes = makeTexture();
+            fboMean = gl.createFramebuffer();
+            fboRes = gl.createFramebuffer();
+            allocateTargets(screenWidth, screenHeight);
+            if (fboType !== gl.UNSIGNED_BYTE &&
+                gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+                // Some drivers advertise half floats but will not render to
+                // them. Asking is the only way to find out.
+                fboType = gl.UNSIGNED_BYTE;
+                gl.deleteTexture(texMean); gl.deleteTexture(texRes);
+                texMean = makeTexture();
+                texRes = makeTexture();
+                allocateTargets(screenWidth, screenHeight);
+            }
+            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             return true;
         } catch (err) {
-            console.warn('De-dither filter unavailable:', err && err.message);
+            console.warn('Undither unavailable:', err && err.message);
             return false;
         }
     })();
+
+    function makeTexture() {
+        const tex = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        return tex;
+    }
+
+    // The intermediate buffers are the size of the emulated screen, so they
+    // have to follow it when the machine changes resolution.
+    function allocateTargets(w, h) {
+        for (const [tex, fbo] of [[texMean, fboMean], [texRes, fboRes]]) {
+            gl.bindTexture(gl.TEXTURE_2D, tex);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, fboType, null);
+            gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+        }
+    }
+
+    function setSize(w, h) {
+        if (!shaderReady) return;
+        allocateTargets(w, h);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        for (const [prog, uniforms] of [[progMean, {}], [progDetect, {u_sens: UNDITHER.sens, u_strength: UNDITHER.strength}],
+                                        [progDetail, {u_strength: UNDITHER.strength, u_detail: UNDITHER.detail}]]) {
+            gl.useProgram(prog);
+            gl.uniform2f(gl.getUniformLocation(prog, 'u_texSize'), w, h);
+            for (const name in uniforms) gl.uniform1f(gl.getUniformLocation(prog, name), uniforms[name]);
+        }
+    }
+    if (shaderReady) setSize(screenWidth, screenHeight);
 
     let isCrisp = true;
     const filterToggle = document.getElementById('filter-toggle');
     function setCrisp(crisp) {
         isCrisp = crisp || !shaderReady;
         if (isCrisp) { glCanvas.style.display = 'none'; iframe.style.opacity = '1'; filterToggle.innerHTML = '<span class="emoji">📺</span>Crisp'; }
-        else { glCanvas.style.display = 'block'; iframe.style.opacity = '0.01'; filterToggle.innerHTML = '<span class="emoji">📺</span>Dedith'; }
+        else { glCanvas.style.display = 'block'; iframe.style.opacity = '0.01'; filterToggle.innerHTML = '<span class="emoji">📺</span>Undith'; }
         savePrefs({ crisp: isCrisp });
     }
     onTap(filterToggle, () => {
@@ -904,17 +1126,33 @@
         filterToggle.classList.add('disabled');
         filterToggle.title = 'WebGL is not available in this browser';
     }
+
     // Called from the one message listener at the top, which is also where
     // the emulator's real screen size is picked up. Two listeners for the same
     // message meant two places that had to agree about what a frame is.
     function drawScreen(msg) {
         if (isCrisp || !shaderReady || !msg.data) return;
+        const w = msg.width || screenWidth, h = msg.height || screenHeight;
         try {
-            gl.bindTexture(gl.TEXTURE_2D, texture);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, msg.width || screenWidth, msg.height || screenHeight,
-                          0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(msg.data));
-            gl.drawArrays(gl.TRIANGLES, 0, 6);
+            gl.bindTexture(gl.TEXTURE_2D, texSrc);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(msg.data));
+            gl.viewport(0, 0, w, h);
+
+            pass(progMean, fboMean, [['u_src', texSrc]]);
+            pass(progDetect, fboRes, [['u_src', texSrc], ['u_mean', texMean]]);
+            pass(progDetail, null, [['u_res', texRes]]);
         } catch (err) { /* a frame that will not upload is not worth reporting */ }
+    }
+
+    function pass(prog, fbo, inputs) {
+        gl.useProgram(prog);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+        for (let unit = 0; unit < inputs.length; unit++) {
+            gl.activeTexture(gl.TEXTURE0 + unit);
+            gl.bindTexture(gl.TEXTURE_2D, inputs[unit][1]);
+            gl.uniform1i(gl.getUniformLocation(prog, inputs[unit][0]), unit);
+        }
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
     }
 
     // Settings Drawer Buttons

--- a/cythera/utilities/check_all.mjs
+++ b/cythera/utilities/check_all.mjs
@@ -5,7 +5,7 @@
 //   node utilities/check_all.mjs --quick     (skip the slow ones)
 //   node utilities/check_all.mjs viewer      (one page: viewer | browser | mobile)
 //
-// There are eleven harnesses across three pages, each with its own argument
+// There are twelve harnesses across three pages, each with its own argument
 // list, spread across three handoff documents. Nobody runs all of them by hand
 // every time, and it showed: two coverage gaps in decoder_snapshot.mjs went
 // unnoticed because a change was verified with the two checks that seemed
@@ -93,9 +93,10 @@ const CHECKS = [
    cmd: ['utilities/zip_export_test.mjs', 'resource_fork_browser.html', APP_RSRC, `${TMP}/check_all.zip`],
    grep: /PNG payloads: .*/},
 
-  {page: 'mobile', name: 'static', cmd: ['utilities/verify_viewer.mjs', 'cythera_mobile.html']},
+  {page: 'mobile', name: 'static', cmd: ['utilities/verify_viewer.mjs', 'mobile.html']},
+  {page: 'mobile', name: 'input', cmd: ['utilities/mobile_input_check.mjs', 'mobile.html']},
   {page: 'mobile', name: 'infinite-mac api', want: ['infinite-mac'],
-   cmd: ['utilities/mobile_api_check.mjs', 'cythera_mobile.html', 'infinite-mac']},
+   cmd: ['utilities/mobile_api_check.mjs', 'mobile.html', 'infinite-mac']},
 ];
 
 // ---- run -------------------------------------------------------------------

--- a/cythera/utilities/check_all.mjs
+++ b/cythera/utilities/check_all.mjs
@@ -5,7 +5,7 @@
 //   node utilities/check_all.mjs --quick     (skip the slow ones)
 //   node utilities/check_all.mjs viewer      (one page: viewer | browser | mobile)
 //
-// There are twelve harnesses across three pages, each with its own argument
+// There are thirteen harnesses across three pages, each with its own argument
 // list, spread across three handoff documents. Nobody runs all of them by hand
 // every time, and it showed: two coverage gaps in decoder_snapshot.mjs went
 // unnoticed because a change was verified with the two checks that seemed
@@ -95,6 +95,7 @@ const CHECKS = [
 
   {page: 'mobile', name: 'static', cmd: ['utilities/verify_viewer.mjs', 'mobile.html']},
   {page: 'mobile', name: 'input', cmd: ['utilities/mobile_input_check.mjs', 'mobile.html']},
+  {page: 'mobile', name: 'undither', cmd: ['utilities/mobile_undither_check.mjs', 'mobile.html', 'cythera_data_viewer.html']},
   {page: 'mobile', name: 'infinite-mac api', want: ['infinite-mac'],
    cmd: ['utilities/mobile_api_check.mjs', 'mobile.html', 'infinite-mac']},
 ];

--- a/cythera/utilities/mobile_api_check.mjs
+++ b/cythera/utilities/mobile_api_check.mjs
@@ -179,14 +179,22 @@ function run({webgl = true} = {}) {
   const winListeners = new Map();
   const docListeners = new Map();
   const store = new Map();
+  // A clock the checks drive. Nothing fires unless a check asks it to, as
+  // before -- but the page now coalesces pointer moves to one a frame and
+  // spaces its button transitions in milliseconds, so there has to be a clock
+  // to ask. See the note on BUTTON_GAP_MS in the page.
+  const clock = {now: 0, queue: []};
+  const schedule = (fn, ms) => { clock.queue.push({fn, at: clock.now + (ms || 0), id: clock.queue.length + 1}); return clock.queue.length; };
+  const cancel = id => { const t = clock.queue.find(t => t.id === id); if (t) t.cancelled = true; };
   const sandbox = {
     console: {log() {}, warn() {}, error() {}},
-    Math, JSON, Date, Object, Array, String, Number, Boolean, Set, Map, Error, TypeError,
+    Math, JSON, Object, Array, String, Number, Boolean, Set, Map, Error, TypeError,
+    Date: Object.assign(function (...a) { return new Date(...a); }, {now: () => clock.now}),
     RegExp, Promise, isNaN, isFinite, parseInt, parseFloat, Infinity, NaN, undefined,
     URL, URLSearchParams, TextEncoder, TextDecoder, Uint8Array, Float32Array, Array_,
-    setTimeout: (fn) => { return 0; },      // never fire timers; the checks drive things directly
-    clearTimeout() {}, setInterval: () => 0, clearInterval() {},
-    requestAnimationFrame: () => 0,
+    setTimeout: schedule, clearTimeout: cancel,
+    setInterval: () => 0, clearInterval() {},
+    requestAnimationFrame: fn => schedule(fn, 16), cancelAnimationFrame: cancel,
     prompt: () => null,
     localStorage: {
       getItem: k => (store.has(k) ? store.get(k) : null),
@@ -223,6 +231,18 @@ function run({webgl = true} = {}) {
   };
   return {
     ctx, posted, threw, registry, btnEls, glCalls, rawPosted,
+    // Frames and timers up to `ms` from now, each at its own time.
+    tick(ms) {
+      const until = clock.now + (ms || 0);
+      for (;;) {
+        const due = clock.queue.filter(t => !t.cancelled && !t.done && t.at <= until).sort((a, b) => a.at - b.at)[0];
+        if (!due) break;
+        clock.now = Math.max(clock.now, due.at);
+        due.done = true;
+        due.fn();
+      }
+      clock.now = until;
+    },
     // A symbol that is not there is a finding, not a crash: this harness has
     // to be able to report on a page that predates the structure it expects.
     peek: n => { try { return ctx.__peek(n); } catch (e) { return undefined; } },
@@ -260,6 +280,7 @@ if (noGl.threw) {
   else ok('start before load', 'messages held until the emulator reports in');
 
   a.fireWindow('message', {origin: 'https://infinitemac.org', data: {type: 'emulator_loaded'}});
+  a.tick(300);      // the press and its release are deliberately spaced
   const types = a.posted.map(p => p.msg.type);
   // The move is not decoration: a click with no move before it lands at 0,0,
   // which on a Mac is the corner of the menu bar.
@@ -364,6 +385,7 @@ if (!app.peek('GESTURES') || !app.peek('recogniseGesture')) {
     if (!/-btn$|-toggle$|-handle$/.test(id)) continue;
     try { el.dispatch('pointerdown', {}); el.dispatch('pointerup', {}); } catch (e) { /* a control that needs more DOM than this */ }
   }
+  a.tick(1000);     // let everything the page queued actually go out
   // Anything the page posts directly, rather than through post().
   for (const p of a.rawPosted) a.posted.push(p);
 

--- a/cythera/utilities/mobile_api_check.mjs
+++ b/cythera/utilities/mobile_api_check.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Checks cythera_mobile.html against the emulator it embeds.
+// Checks mobile.html against the emulator it embeds.
 //
-//   node utilities/mobile_api_check.mjs cythera_mobile.html infinite-mac
+//   node utilities/mobile_api_check.mjs mobile.html infinite-mac
 //
 // The page is a touch shell around an infinitemac.org embed, and everything it
 // sends -- postMessage payloads, key codes, iframe query parameters, emulator
@@ -27,7 +27,7 @@ import {readFileSync, existsSync} from 'node:fs';
 import vm from 'node:vm';
 import {pageSource} from './page_scripts.mjs';
 
-const [htmlPath = 'cythera_mobile.html', repoPath = 'infinite-mac'] = process.argv.slice(2);
+const [htmlPath = 'mobile.html', repoPath = 'infinite-mac'] = process.argv.slice(2);
 for (const p of [htmlPath, repoPath]) {
   if (!existsSync(p)) { console.error('missing: ' + p); process.exit(2); }
 }
@@ -193,7 +193,7 @@ function run({webgl = true} = {}) {
       setItem: (k, v) => store.set(k, String(v)),
       removeItem: k => store.delete(k),
     },
-    location: {search: '', href: 'file:///cythera_mobile.html', hash: ''},
+    location: {search: '', href: 'file:///mobile.html', hash: ''},
     innerWidth: 390, innerHeight: 844,
     document: {
       getElementById: id => registry.get(id) || registry.set(id, makeEl('div', id)).get(id),
@@ -261,7 +261,9 @@ if (noGl.threw) {
 
   a.fireWindow('message', {origin: 'https://infinitemac.org', data: {type: 'emulator_loaded'}});
   const types = a.posted.map(p => p.msg.type);
-  const want = ['emulator_unpause', 'emulator_mouse_down', 'emulator_mouse_up'];
+  // The move is not decoration: a click with no move before it lands at 0,0,
+  // which on a Mac is the corner of the menu bar.
+  const want = ['emulator_unpause', 'emulator_mouse_move', 'emulator_mouse_down', 'emulator_mouse_up'];
   if (JSON.stringify(types) === JSON.stringify(want)) ok('start after load', types.join(', '));
   else fail('start after load', 'sent ' + JSON.stringify(types));
 

--- a/cythera/utilities/mobile_input_check.mjs
+++ b/cythera/utilities/mobile_input_check.mjs
@@ -134,7 +134,7 @@ function buildPage({webgl = true} = {}) {
   byClass.set('.dir-btn', []);
 
   const posted = [];
-  registry.get('mac-iframe').contentWindow = {postMessage: msg => posted.push(msg)};
+  registry.get('mac-iframe').contentWindow = {postMessage: msg => posted.push(Object.assign({at: clock.now}, msg))};
 
   const glCalls = [];
   registry.get('gl-canvas').getContext = kind => {
@@ -162,12 +162,18 @@ function buildPage({webgl = true} = {}) {
 
   const sandbox = {
     console: {log() {}, warn() {}, error() {}},
-    Math, JSON, Date, Object, Array, String, Number, Boolean, Set, Map, Error, TypeError,
+    Math, JSON, Object, Array, String, Number, Boolean, Set, Map, Error, TypeError,
+    Date: Object.assign(function (...a) { return new Date(...a); }, {now: () => clock.now}),
     RegExp, Promise, isNaN, isFinite, parseInt, parseFloat, Infinity, NaN, undefined,
     URL, URLSearchParams, Uint8Array, Float32Array,
     setTimeout: (fn, ms) => { clock.queue.push({fn, at: clock.now + (ms || 0), id: clock.queue.length + 1}); return clock.queue.length; },
     clearTimeout: id => { const t = clock.queue.find(t => t.id === id); if (t) t.cancelled = true; },
-    setInterval: () => 0, clearInterval() {}, requestAnimationFrame: () => 0,
+    setInterval: () => 0, clearInterval() {},
+    // The page coalesces pointer moves to one a frame and spaces its button
+    // transitions in milliseconds, so both have to be on the same clock as the
+    // timers or none of it is reproducible.
+    requestAnimationFrame: fn => { clock.queue.push({fn, at: clock.now + 16, id: clock.queue.length + 1}); return clock.queue.length; },
+    cancelAnimationFrame: id => { const t = clock.queue.find(t => t.id === id); if (t) t.cancelled = true; },
     localStorage: {
       getItem: k => (store.has(k) ? store.get(k) : null),
       setItem: (k, v) => store.set(k, String(v)),
@@ -198,26 +204,34 @@ function buildPage({webgl = true} = {}) {
     peek: n => { try { return ctx.__peek(n); } catch (e) { return undefined; } },
     fireWindow: (t, ev) => fire(winListeners, t, ev),
     fireDoc: (t, ev) => fire(docListeners, t, ev),
-    // Timers, in order, until nothing is due. The page uses them to hold a
-    // click down for 50ms and to lock a trackpad drag after 400ms.
+    // Everything the page has queued -- frames and timers alike -- up to the
+    // moment `ms` from now, in order.
+    settle() { api.tick(300); },
     tick(ms) {
-      clock.now += (ms || 0);
+      // A real event loop, not one jump: the clock stops at each callback's
+      // own time, so a callback that schedules another 40ms out gets its turn
+      // inside the same tick and reads a Date.now() that makes sense.
+      const until = clock.now + (ms || 0);
       for (;;) {
-        const due = clock.queue.filter(t => !t.cancelled && !t.done && t.at <= clock.now).sort((a, b) => a.at - b.at)[0];
+        const due = clock.queue.filter(t => !t.cancelled && !t.done && t.at <= until).sort((a, b) => a.at - b.at)[0];
         if (!due) break;
+        clock.now = Math.max(clock.now, due.at);
         due.done = true;
         due.fn();
       }
+      clock.now = until;
     },
     start() {
       registry.get('start-overlay').dispatch('pointerdown', {});
       api.fireWindow('message', {origin: 'https://infinitemac.org', data: {type: 'emulator_loaded'}});
+      api.settle();
       posted.length = 0;
     },
     // Tell the page what the emulator actually came up with, the way the
     // emulator does.
     screen(width, height) {
       api.fireWindow('message', {origin: 'https://infinitemac.org', data: {type: 'emulator_screen', width, height}});
+      api.settle();
       posted.length = 0;
     },
     types: () => posted.map(m => m.type),
@@ -263,6 +277,7 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   const mouse = pointer(a.el('touch-overlay'), 1, 'mouse');
   mouse.down(VIEW_W / 2, VIEW_H / 2);
   mouse.up(VIEW_W / 2, VIEW_H / 2);
+  a.settle();
   const move = a.lastMove();
   check(a.buttons().join(' ') === 'down0 up0', 'a mouse click reaches the emulator', a.buttons().join(' ') || 'nothing was sent');
   check(!!move && near(move.x, 320) && near(move.y, 240),
@@ -275,12 +290,14 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   a.start(); a.screen(640, 480);
   const mouse = pointer(a.el('touch-overlay'), 1, 'mouse');
   mouse.move(VIEW_W / 2, VIEW_H / 2);
+  a.settle();
   const hover = a.lastMove();
   check(!!hover && near(hover.x, 320) && near(hover.y, 240),
         'a mouse with no button down still moves the pointer', hover ? `(${hover.x}, ${hover.y})` : 'nothing');
   a.clear();
   mouse.down(100, 400, {button: 2});
   mouse.up(100, 400, {button: 2});
+  a.settle();
   check(a.buttons().join(' ') === 'down2 up2', 'the right button goes through as the right button', a.buttons().join(' '));
   const menu = a.el('touch-overlay').dispatch('contextmenu', {});
   check(menu.defaultPrevented, 'the browser context menu is suppressed');
@@ -294,6 +311,7 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   finger.down(100, 400);
   a.clear();
   finger.cancel(100, 400);
+  a.settle();
   check(a.buttons().join(' ') === 'up0', 'a cancelled gesture releases the button', a.buttons().join(' ') || 'the button stayed down');
 
   const b = buildPage();
@@ -302,6 +320,7 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   b.clear();
   b.ctx.document.hidden = true;
   b.fireDoc('visibilitychange', {});
+  b.settle();
   check(b.buttons().join(' ') === 'up0', 'hiding the page releases the button', b.buttons().join(' ') || 'the button stayed down');
 }
 
@@ -312,10 +331,11 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   a.start(); a.screen(640, 480);
   const finger = pointer(a.el('touch-overlay'), 1, 'touch');
   finger.down(VIEW_W / 2, VIEW_H / 2);
+  a.settle();
   const down = a.lastMove();
   finger.move(VIEW_W / 2 + 30, VIEW_H / 2);
   finger.up(VIEW_W / 2 + 30, VIEW_H / 2);
-  a.tick(100);
+  a.settle();
   check(a.buttons().join(' ') === 'down0 up0', 'direct: a finger drag holds the button down', a.buttons().join(' '));
   check(!!down && near(down.x, 320) && near(down.y, 240 - 12, 1.5),
         'direct: aim sits a little above the fingertip', down ? `(${down.x}, ${down.y})` : 'nothing');
@@ -328,9 +348,10 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   b.clear();
   const t = pointer(b.el('touch-overlay'), 1, 'touch');
   t.down(100, 400);
+  b.tick(50);
   const noJump = b.moves().length === 0;
   t.up(100, 400);
-  b.tick(100);
+  b.settle();
   check(noJump, 'trackpad: the pointer does not jump to the finger');
   check(b.buttons().join(' ') === 'down0 up0', 'trackpad: a tap is a click', b.buttons().join(' '));
 
@@ -344,7 +365,7 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   c.tick(500);
   const locked = c.buttons().join(' ') === 'down0';
   held.up(100, 400);
-  c.tick(100);
+  c.settle();
   check(locked && c.buttons().join(' ') === 'down0 up0', 'trackpad: holding still locks a drag', c.buttons().join(' '));
 
   // Pan View: dragging moves the view, and the pointer stays in the middle.
@@ -356,7 +377,7 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   pan.down(200, 400);
   pan.move(160, 380);
   pan.up(160, 380);
-  d.tick(100);
+  d.settle();
   check(d.buttons().length === 0, 'pan view: a drag does not click', d.buttons().join(' '));
   check(d.moves().length > 0, 'pan view: the pointer is kept on the crosshair');
 }
@@ -369,25 +390,26 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   const one = pointer(overlay, 1, 'touch'), two = pointer(overlay, 2, 'touch');
   one.down(150, 400);
   two.down(250, 400);
-  a.clear();
   one.up(150, 400);
   two.up(250, 400);
-  a.tick(100);
-  check(a.buttons().join(' ') === 'down2 up2', 'a two-finger tap is a right click', a.buttons().join(' ') || 'nothing');
+  a.settle();
+  check(a.buttons().slice(-2).join(' ') === 'down2 up2', 'a two-finger tap is a right click', a.buttons().join(' ') || 'nothing');
 
   const b = buildPage();
   b.start(); b.screen(640, 480);
   const o = b.el('touch-overlay');
   const p1 = pointer(o, 1, 'touch'), p2 = pointer(o, 2, 'touch');
   p1.down(150, 400);
+  b.settle();
   const landed = b.buttons().join(' ');       // direct mode presses as it lands
   p2.down(250, 400);
+  b.settle();
   const handedBack = b.buttons().join(' ');
   b.clear();
   p2.move(350, 400);
   const zoomed = parseTransform(b.el('pan-zoom-container').style.transform).s;
   p1.up(150, 400); p2.up(350, 400);
-  b.tick(100);
+  b.settle();
   check(zoomed > 1.2, 'pinching zooms the view', 'scale ' + zoomed.toFixed(2));
   // Direct mode presses the button the moment a finger lands, which is what
   // makes dragging work; a second finger has to take that press back, or the
@@ -458,16 +480,92 @@ ok('page initialises', `${boot.glCalls.length} GL calls`);
   for (let y = 20; y <= 120; y += 20) stroke.move(20, y);     // down
   for (let x = 20; x <= 120; x += 20) stroke.move(x, 120);    // then right: an L
   stroke.up(120, 120);
-  a.tick(100);
+  a.settle();
   check(a.keys().join(' ') === '+KeyL -KeyL', 'a gesture can be drawn with a mouse', a.keys().join(' ') || 'nothing');
 }
 
-// ---- 10. the screen size comes from the emulator ---------------------------
+/* ---- 10. what the emulated Mac actually ends up seeing ---------------------
+   The checks above ask what the page sends. This one asks what survives.
+
+   From updateInputBufferWithEvents() in the emulator's own
+   src/emulator/common/common.ts: everything queued between two of its input
+   syncs is collapsed into a single state. The FIRST mousemove of the batch is
+   kept and every later one is dropped; each mousedown/mouseup overwrites the
+   one before it, because what reaches the Mac is a button LEVEL, not an edge.
+
+   So a press and its release inside one window cancel out and the click never
+   happens, and a release and the next press inside one window lose the
+   release -- the level stays down and the Mac reads the next tap somewhere
+   else as a DRAG from the last one. That is what "Direct mode drags in random
+   directions when I tap" was.
+
+   The sync period is not fixed: the emulator consumes input when the guest
+   next polls, so a busy or slow machine has a longer window. Hence the sweep. */
+function asTheMacSeesIt(posted, syncEveryMs) {
+  const states = [];
+  let batch = [], nextSync = syncEveryMs;
+  const flush = () => {
+    if (!batch.length) return;
+    let pos = null, button = null;
+    for (const m of batch) {
+      if (m.type === 'emulator_mouse_move') { if (pos === null) pos = {x: m.x, y: m.y}; }
+      else if (m.type === 'emulator_mouse_down') button = 'down';
+      else if (m.type === 'emulator_mouse_up') button = 'up';
+    }
+    if (pos || button) states.push({pos, button});
+    batch = [];
+  };
+  for (const m of posted) {
+    while (m.at >= nextSync) { flush(); nextSync += syncEveryMs; }
+    batch.push(m);
+  }
+  flush();
+  return states;
+}
+
+// The level the Mac is holding, and where the pointer was each time it changed.
+function buttonStory(states) {
+  const story = [];
+  let level = 'up', at = null;
+  for (const s of states) {
+    if (s.pos) at = s.pos;
+    if (s.button && s.button !== level) { level = s.button; story.push(`${level}@${at ? at.x + ',' + at.y : '?'}`); }
+  }
+  return story;
+}
+
+{
+  // Up to a 50ms window, i.e. a guest polling at 20Hz. Past that the emulator
+  // would swallow a physical mouse click as well, so it is not this page's
+  // problem to solve.
+  const PERIODS = [8, 16, 33, 50];
+  let clean = [], broken = [];
+  for (const period of PERIODS) {
+    const a = buildPage();
+    a.start(); a.screen(640, 480);
+    const finger = pointer(a.el('touch-overlay'), 1, 'touch');
+    // One tap, then another somewhere else -- the thing that dragged.
+    finger.down(120, 300); finger.up(120, 300);
+    a.tick(120);
+    finger.down(300, 500); finger.up(300, 500);
+    a.settle();
+    const story = buttonStory(asTheMacSeesIt(a.posted, period));
+    // Two taps: down, up, down, up. Anything else and the Mac is holding the
+    // button across a move, which is a drag.
+    const shape = story.map(s => s.split('@')[0]).join(' ');
+    (shape === 'down up down up' ? clean : broken).push(`${period}ms: ${story.join(' ') || 'nothing'}`);
+  }
+  check(broken.length === 0, 'two taps are two clicks, whatever the emulator\'s sync period',
+        broken.length ? broken.join(' | ') : clean.length + ' periods, 8ms to 50ms');
+}
+
+// ---- 11. the screen size comes from the emulator ---------------------------
 {
   const a = buildPage();
   a.start();
   a.screen(800, 600);
   pointer(a.el('touch-overlay'), 1, 'mouse').move(VIEW_W / 2, VIEW_H / 2);
+  a.settle();
   const m = a.lastMove();
   check(!!m && near(m.x, 400) && near(m.y, 300),
         'coordinates follow the resolution the emulator reports', m ? `(${m.x}, ${m.y}) of 800x600` : 'nothing');

--- a/cythera/utilities/mobile_input_check.mjs
+++ b/cythera/utilities/mobile_input_check.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+// Drives mobile.html's pointer, wheel and keyboard handling in a stub DOM.
+//
+//   node utilities/mobile_input_check.mjs mobile.html
+//
+// mobile_api_check.mjs asks whether what the page sends is in the emulator's
+// API. This asks the other half of the question: whether anything is sent at
+// all, for each of the ways a person can touch the thing.
+//
+// It was written after the page spent a long time being unusable with a mouse.
+// #touch-overlay is stretched across the emulator's iframe so that it can
+// catch touches, so it also catches every click -- and it listened for
+// `touchstart`, `touchmove` and `touchend`, which a mouse does not produce.
+// The emulator was on screen, visibly running, and could not be clicked.
+// Nothing noticed, because every check ran the page rather than used it.
+//
+// So the stub DOM here is a little more honest than a pile of no-ops: an
+// element's bounding rectangle is computed from the CSS transforms the page
+// itself set, which is what makes "a click at the middle of the window lands
+// at the middle of the emulated screen" a real assertion about the coordinate
+// arithmetic rather than about a hard-coded rectangle.
+
+import {readFileSync, existsSync} from 'node:fs';
+import vm from 'node:vm';
+import {pageSource} from './page_scripts.mjs';
+
+const [htmlPath = 'mobile.html'] = process.argv.slice(2);
+if (!existsSync(htmlPath)) { console.error('missing: ' + htmlPath); process.exit(2); }
+
+const html = readFileSync(htmlPath, 'utf8');
+const js = pageSource(htmlPath);
+
+let failures = 0;
+const fail = (what, detail) => { failures++; console.log('  FAIL ' + what + (detail ? ' — ' + detail : '')); };
+const ok = (what, detail) => console.log('  ok   ' + what + (detail ? ' — ' + detail : ''));
+const check = (cond, what, detail) => cond ? ok(what, detail) : fail(what, detail);
+
+const VIEW_W = 390, VIEW_H = 844;
+
+// ---- the stub DOM ----------------------------------------------------------
+function parseTransform(t) {
+  const out = {x: 0, y: 0, s: 1};
+  if (!t) return out;
+  const tr = /translate\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px\s*\)/.exec(t);
+  if (tr) { out.x = Number(tr[1]); out.y = Number(tr[2]); }
+  const sc = /scale\(\s*(-?[\d.]+)\s*\)/.exec(t);
+  if (sc) out.s = Number(sc[1]);
+  return out;
+}
+
+function makeEl(tag, id, doc) {
+  const listeners = new Map();
+  const captured = new Set();
+  const el = {
+    tagName: String(tag).toUpperCase(), id: id || '', tabIndex: -1, title: '', hidden: false,
+    style: {}, innerHTML: '', textContent: '', value: '', src: '', width: 0, height: 0,
+    className: '', children: [], dataset: {}, isContentEditable: false,
+    classList: {
+      _s: new Set(),
+      add(...c) { c.forEach(x => this._s.add(x)); },
+      remove(...c) { c.forEach(x => this._s.delete(x)); },
+      contains(c) { return this._s.has(c); },
+      toggle(c, on) { const v = on === undefined ? !this._s.has(c) : on; if (v) this._s.add(c); else this._s.delete(c); return v; },
+    },
+    appendChild(c) { el.children.push(c); return c; },
+    setAttribute(k, v) { if (k === 'class') el.className = String(v); el.dataset['attr_' + k] = String(v); },
+    getAttribute(k) { return k === 'class' ? el.className : (el.dataset['attr_' + k] ?? null); },
+    addEventListener(t, fn) { (listeners.get(t) || listeners.set(t, []).get(t)).push(fn); },
+    removeEventListener(t, fn) { const l = listeners.get(t) || []; const i = l.indexOf(fn); if (i >= 0) l.splice(i, 1); },
+    listenerCount(t) { return (listeners.get(t) || []).length; },
+    dispatch(t, ev) {
+      const event = Object.assign(
+        {type: t, target: el, preventDefault() { event.defaultPrevented = true; }, stopPropagation() {}},
+        ev);
+      for (const fn of (listeners.get(t) || []).slice()) fn(event);
+      return event;
+    },
+    setPointerCapture(pid) { captured.add(pid); },
+    releasePointerCapture(pid) { captured.delete(pid); },
+    hasPointerCapture(pid) { return captured.has(pid); },
+    focus() { doc.activeElement = el; }, blur() {}, click() { el.dispatch('click', {}); }, remove() {},
+    // Derived from what the page put in style, so the geometry under test is
+    // the page's own rather than this file's idea of it.
+    getBoundingClientRect() {
+      const own = parseTransform(el.style.transform);
+      const w = parseFloat(el.style.width) || el.offsetWidth || 0;
+      const h = parseFloat(el.style.height) || el.offsetHeight || 0;
+      const parent = el.id === 'scale-target' ? doc.getElementById('pan-zoom-container') : null;
+      const pz = parent ? parseTransform(parent.style.transform) : {x: 0, y: 0, s: 1};
+      const left = pz.x + own.x * pz.s, top = pz.y + own.y * pz.s;
+      const width = w * own.s * pz.s, height = h * own.s * pz.s;
+      return {left, top, width, height, right: left + width, bottom: top + height};
+    },
+    getContext: () => null, offsetWidth: 160, offsetHeight: 180,
+    querySelector: sel => el._q(sel)[0] || null,
+    querySelectorAll: sel => el._q(sel),
+    _q: sel => el.children.filter(c => c.className.split(/\s+/).includes(String(sel).replace(/^\./, ''))),
+  };
+  return el;
+}
+
+function buildPage({webgl = true} = {}) {
+  const registry = new Map();
+  const byClass = new Map();
+  const clock = {now: 0, queue: []};
+  const doc = {};
+  const mk = (tag, id) => makeEl(tag, id, doc);
+
+  for (const m of html.matchAll(/\bid="([^"]+)"/g)) registry.set(m[1], mk('div', m[1]));
+  // Elements the markup hides to begin with. Whether the help panel is open
+  // decides where the keyboard goes, so getting this wrong would test nothing.
+  for (const m of html.matchAll(/\bid="([^"]+)"[^>]*\shidden(?=[\s>])/g)) registry.get(m[1]).hidden = true;
+  registry.get('modal-input').tagName = 'INPUT';
+  registry.get('hidden-keyboard').tagName = 'INPUT';
+
+  for (const winId of ['hud-dpad', 'hud-actions']) {
+    const win = registry.get(winId);
+    for (const cls of ['drag-handle', 'resize-handle', 'mode-toggle', 'btn-grid', 'gesture-area']) {
+      const child = mk('div');
+      child.className = cls;
+      win.appendChild(child);
+    }
+  }
+  const codes = [...new Set([...html.matchAll(/data-code="([^"]+)"/g)].map(m => m[1]))];
+  const btnEls = codes.map(code => {
+    const b = mk('div');
+    b.className = 'btn';
+    b.setAttribute('data-code', code);
+    return b;
+  });
+  byClass.set('.btn[data-code]', btnEls);
+  byClass.set('.hud-window', ['hud-dpad', 'hud-actions'].map(id => registry.get(id)));
+  byClass.set('.action-btn', []);
+  byClass.set('.dir-btn', []);
+
+  const posted = [];
+  registry.get('mac-iframe').contentWindow = {postMessage: msg => posted.push(msg)};
+
+  const glCalls = [];
+  registry.get('gl-canvas').getContext = kind => {
+    if (kind !== 'webgl' || !webgl) return null;
+    return new Proxy({
+      VERTEX_SHADER: 1, FRAGMENT_SHADER: 2, COMPILE_STATUS: 3, LINK_STATUS: 4,
+      getShaderParameter: () => true, getProgramParameter: () => true,
+      getShaderInfoLog: () => '', getProgramInfoLog: () => '',
+      getAttribLocation: () => 0, getUniformLocation: () => ({}),
+    }, {get(t, k) { return k in t ? t[k] : (...a) => { glCalls.push(String(k)); return {}; }; }});
+  };
+  registry.get('gesture-canvas').getContext = () => new Proxy({}, {get: () => () => ({})});
+
+  const winListeners = new Map(), docListeners = new Map(), store = new Map();
+  Object.assign(doc, {
+    getElementById: id => registry.get(id) || registry.set(id, mk('div', id)).get(id),
+    createElement: t => mk(t),
+    querySelector: sel => (byClass.get(sel) || [])[0] || null,
+    querySelectorAll: sel => byClass.get(sel) || [],
+    addEventListener(t, fn) { (docListeners.get(t) || docListeners.set(t, []).get(t)).push(fn); },
+    removeEventListener() {},
+    documentElement: mk('html'), body: mk('body'),
+    hidden: false, fullscreenElement: null, activeElement: null,
+  });
+
+  const sandbox = {
+    console: {log() {}, warn() {}, error() {}},
+    Math, JSON, Date, Object, Array, String, Number, Boolean, Set, Map, Error, TypeError,
+    RegExp, Promise, isNaN, isFinite, parseInt, parseFloat, Infinity, NaN, undefined,
+    URL, URLSearchParams, Uint8Array, Float32Array,
+    setTimeout: (fn, ms) => { clock.queue.push({fn, at: clock.now + (ms || 0), id: clock.queue.length + 1}); return clock.queue.length; },
+    clearTimeout: id => { const t = clock.queue.find(t => t.id === id); if (t) t.cancelled = true; },
+    setInterval: () => 0, clearInterval() {}, requestAnimationFrame: () => 0,
+    localStorage: {
+      getItem: k => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: k => store.delete(k),
+    },
+    location: {search: '', href: 'file:///' + htmlPath, hash: ''},
+    innerWidth: VIEW_W, innerHeight: VIEW_H,
+    document: doc,
+    addEventListener(t, fn) { (winListeners.get(t) || winListeners.set(t, []).get(t)).push(fn); },
+    removeEventListener() {},
+  };
+  sandbox.window = sandbox;
+  sandbox.globalThis = sandbox;
+  const ctx = vm.createContext(sandbox);
+  let threw = null;
+  try {
+    new vm.Script(js + '\n;window.__peek = n => eval(n);\n', {filename: htmlPath}).runInContext(ctx);
+  } catch (e) { threw = e; }
+
+  const fire = (map, type, ev) => {
+    const event = Object.assign({type, preventDefault() { event.defaultPrevented = true; }, stopPropagation() {}}, ev);
+    for (const fn of (map.get(type) || []).slice()) fn(event);
+    return event;
+  };
+  const api = {
+    ctx, posted, threw, registry, btnEls, glCalls, clock,
+    el: id => registry.get(id),
+    peek: n => { try { return ctx.__peek(n); } catch (e) { return undefined; } },
+    fireWindow: (t, ev) => fire(winListeners, t, ev),
+    fireDoc: (t, ev) => fire(docListeners, t, ev),
+    // Timers, in order, until nothing is due. The page uses them to hold a
+    // click down for 50ms and to lock a trackpad drag after 400ms.
+    tick(ms) {
+      clock.now += (ms || 0);
+      for (;;) {
+        const due = clock.queue.filter(t => !t.cancelled && !t.done && t.at <= clock.now).sort((a, b) => a.at - b.at)[0];
+        if (!due) break;
+        due.done = true;
+        due.fn();
+      }
+    },
+    start() {
+      registry.get('start-overlay').dispatch('pointerdown', {});
+      api.fireWindow('message', {origin: 'https://infinitemac.org', data: {type: 'emulator_loaded'}});
+      posted.length = 0;
+    },
+    // Tell the page what the emulator actually came up with, the way the
+    // emulator does.
+    screen(width, height) {
+      api.fireWindow('message', {origin: 'https://infinitemac.org', data: {type: 'emulator_screen', width, height}});
+      posted.length = 0;
+    },
+    types: () => posted.map(m => m.type),
+    moves: () => posted.filter(m => m.type === 'emulator_mouse_move'),
+    lastMove: () => api.moves()[api.moves().length - 1],
+    buttons: () => posted.filter(m => m.type === 'emulator_mouse_down' || m.type === 'emulator_mouse_up')
+                         .map(m => `${m.type === 'emulator_mouse_down' ? 'down' : 'up'}${m.button}`),
+    keys: () => posted.filter(m => m.type === 'emulator_key_down' || m.type === 'emulator_key_up')
+                      .map(m => `${m.type === 'emulator_key_down' ? '+' : '-'}${m.code}`),
+    clear() { posted.length = 0; },
+  };
+  return api;
+}
+
+// A gesture, spelled the way the browser delivers one.
+function pointer(el, id, type) {
+  const send = (kind, x, y, extra) =>
+    el.dispatch(kind, Object.assign({pointerId: id, pointerType: type, clientX: x, clientY: y, button: 0, buttons: 1}, extra));
+  return {
+    down: (x, y, extra) => send('pointerdown', x, y, extra),
+    move: (x, y, extra) => send('pointermove', x, y, extra),
+    up: (x, y, extra) => send('pointerup', x, y, extra),
+    cancel: (x, y, extra) => send('pointercancel', x, y, extra),
+  };
+}
+
+const near = (a, b, tol = 1.5) => Math.abs(a - b) <= tol;
+
+// ---- 1. it runs -------------------------------------------------------------
+const boot = buildPage();
+if (boot.threw) {
+  fail('page initialises', boot.threw.message);
+  console.log('\nFAIL — the page did not run, so nothing below could be checked');
+  process.exit(1);
+}
+ok('page initialises', `${boot.glCalls.length} GL calls`);
+
+// ---- 2. a mouse can click the emulator -------------------------------------
+{
+  const a = buildPage();
+  a.start();
+  a.screen(640, 480);
+  const mouse = pointer(a.el('touch-overlay'), 1, 'mouse');
+  mouse.down(VIEW_W / 2, VIEW_H / 2);
+  mouse.up(VIEW_W / 2, VIEW_H / 2);
+  const move = a.lastMove();
+  check(a.buttons().join(' ') === 'down0 up0', 'a mouse click reaches the emulator', a.buttons().join(' ') || 'nothing was sent');
+  check(!!move && near(move.x, 320) && near(move.y, 240),
+        'the click lands where the mouse is', move ? `(${move.x}, ${move.y}) of 640x480` : 'no move was sent');
+}
+
+// ---- 3. hovering, and the right button -------------------------------------
+{
+  const a = buildPage();
+  a.start(); a.screen(640, 480);
+  const mouse = pointer(a.el('touch-overlay'), 1, 'mouse');
+  mouse.move(VIEW_W / 2, VIEW_H / 2);
+  const hover = a.lastMove();
+  check(!!hover && near(hover.x, 320) && near(hover.y, 240),
+        'a mouse with no button down still moves the pointer', hover ? `(${hover.x}, ${hover.y})` : 'nothing');
+  a.clear();
+  mouse.down(100, 400, {button: 2});
+  mouse.up(100, 400, {button: 2});
+  check(a.buttons().join(' ') === 'down2 up2', 'the right button goes through as the right button', a.buttons().join(' '));
+  const menu = a.el('touch-overlay').dispatch('contextmenu', {});
+  check(menu.defaultPrevented, 'the browser context menu is suppressed');
+}
+
+// ---- 4. nothing is left held -----------------------------------------------
+{
+  const a = buildPage();
+  a.start(); a.screen(640, 480);
+  const finger = pointer(a.el('touch-overlay'), 1, 'touch');
+  finger.down(100, 400);
+  a.clear();
+  finger.cancel(100, 400);
+  check(a.buttons().join(' ') === 'up0', 'a cancelled gesture releases the button', a.buttons().join(' ') || 'the button stayed down');
+
+  const b = buildPage();
+  b.start(); b.screen(640, 480);
+  pointer(b.el('touch-overlay'), 1, 'touch').down(100, 400);
+  b.clear();
+  b.ctx.document.hidden = true;
+  b.fireDoc('visibilitychange', {});
+  check(b.buttons().join(' ') === 'up0', 'hiding the page releases the button', b.buttons().join(' ') || 'the button stayed down');
+}
+
+// ---- 5. the touch modes ----------------------------------------------------
+{
+  // Direct: the finger presses as it lands, so a drag is a drag.
+  const a = buildPage();
+  a.start(); a.screen(640, 480);
+  const finger = pointer(a.el('touch-overlay'), 1, 'touch');
+  finger.down(VIEW_W / 2, VIEW_H / 2);
+  const down = a.lastMove();
+  finger.move(VIEW_W / 2 + 30, VIEW_H / 2);
+  finger.up(VIEW_W / 2 + 30, VIEW_H / 2);
+  a.tick(100);
+  check(a.buttons().join(' ') === 'down0 up0', 'direct: a finger drag holds the button down', a.buttons().join(' '));
+  check(!!down && near(down.x, 320) && near(down.y, 240 - 12, 1.5),
+        'direct: aim sits a little above the fingertip', down ? `(${down.x}, ${down.y})` : 'nothing');
+
+  // Trackpad: a tap clicks where the pointer already is, and the pointer moves
+  // relatively rather than jumping to the finger.
+  const b = buildPage();
+  b.start(); b.screen(640, 480);
+  b.peek('setTouchMode')(1);
+  b.clear();
+  const t = pointer(b.el('touch-overlay'), 1, 'touch');
+  t.down(100, 400);
+  const noJump = b.moves().length === 0;
+  t.up(100, 400);
+  b.tick(100);
+  check(noJump, 'trackpad: the pointer does not jump to the finger');
+  check(b.buttons().join(' ') === 'down0 up0', 'trackpad: a tap is a click', b.buttons().join(' '));
+
+  // Trackpad, held still: the drag lock after 0.4s.
+  const c = buildPage();
+  c.start(); c.screen(640, 480);
+  c.peek('setTouchMode')(1);
+  c.clear();
+  const held = pointer(c.el('touch-overlay'), 1, 'touch');
+  held.down(100, 400);
+  c.tick(500);
+  const locked = c.buttons().join(' ') === 'down0';
+  held.up(100, 400);
+  c.tick(100);
+  check(locked && c.buttons().join(' ') === 'down0 up0', 'trackpad: holding still locks a drag', c.buttons().join(' '));
+
+  // Pan View: dragging moves the view, and the pointer stays in the middle.
+  const d = buildPage();
+  d.start(); d.screen(640, 480);
+  d.peek('setTouchMode')(2);
+  d.clear();
+  const pan = pointer(d.el('touch-overlay'), 1, 'touch');
+  pan.down(200, 400);
+  pan.move(160, 380);
+  pan.up(160, 380);
+  d.tick(100);
+  check(d.buttons().length === 0, 'pan view: a drag does not click', d.buttons().join(' '));
+  check(d.moves().length > 0, 'pan view: the pointer is kept on the crosshair');
+}
+
+// ---- 6. two fingers --------------------------------------------------------
+{
+  const a = buildPage();
+  a.start(); a.screen(640, 480);
+  const overlay = a.el('touch-overlay');
+  const one = pointer(overlay, 1, 'touch'), two = pointer(overlay, 2, 'touch');
+  one.down(150, 400);
+  two.down(250, 400);
+  a.clear();
+  one.up(150, 400);
+  two.up(250, 400);
+  a.tick(100);
+  check(a.buttons().join(' ') === 'down2 up2', 'a two-finger tap is a right click', a.buttons().join(' ') || 'nothing');
+
+  const b = buildPage();
+  b.start(); b.screen(640, 480);
+  const o = b.el('touch-overlay');
+  const p1 = pointer(o, 1, 'touch'), p2 = pointer(o, 2, 'touch');
+  p1.down(150, 400);
+  const landed = b.buttons().join(' ');       // direct mode presses as it lands
+  p2.down(250, 400);
+  const handedBack = b.buttons().join(' ');
+  b.clear();
+  p2.move(350, 400);
+  const zoomed = parseTransform(b.el('pan-zoom-container').style.transform).s;
+  p1.up(150, 400); p2.up(350, 400);
+  b.tick(100);
+  check(zoomed > 1.2, 'pinching zooms the view', 'scale ' + zoomed.toFixed(2));
+  // Direct mode presses the button the moment a finger lands, which is what
+  // makes dragging work; a second finger has to take that press back, or the
+  // Mac is left holding the mouse down for the length of the pinch.
+  check(landed === 'down0' && handedBack === 'down0 up0',
+        'a second finger takes back the press the first one made', handedBack);
+  check(b.buttons().length === 0, 'and the pinch itself is not a click', b.buttons().join(' '));
+}
+
+// ---- 7. the wheel ----------------------------------------------------------
+{
+  const a = buildPage();
+  a.start(); a.screen(640, 480);
+  const ev = a.el('touch-overlay').dispatch('wheel', {clientX: 195, clientY: 422, deltaY: -240, deltaMode: 0});
+  const scale = parseTransform(a.el('pan-zoom-container').style.transform).s;
+  check(scale > 1.2, 'the wheel zooms', 'scale ' + scale.toFixed(2));
+  check(ev.defaultPrevented, 'the wheel does not also scroll the page');
+}
+
+// ---- 8. a real keyboard ----------------------------------------------------
+{
+  const a = buildPage();
+  a.start();
+  a.fireDoc('keydown', {code: 'Numpad8', key: '8', target: {tagName: 'BODY'}});
+  a.fireDoc('keyup', {code: 'Numpad8', key: '8', target: {tagName: 'BODY'}});
+  check(a.keys().join(' ') === '+Numpad8 -Numpad8', 'a keyboard drives the emulated Mac', a.keys().join(' ') || 'nothing was sent');
+
+  a.clear();
+  a.fireDoc('keydown', {code: 'KeyG', key: 'g', target: a.el('modal-input')});
+  check(a.keys().length === 0, 'typing in a field of this page stays in the field', a.keys().join(' '));
+
+  a.clear();
+  a.fireDoc('keydown', {code: 'KeyR', key: 'r', ctrlKey: true, target: {tagName: 'BODY'}});
+  check(a.keys().length === 0, 'the browser keeps its own shortcuts', a.keys().join(' '));
+
+  // macOS swallows the keyup for a key pressed while Command is held, so the
+  // Mac is left holding it. Infinite Mac works around this for its own
+  // keyboard; anything sent through the embed API arrives past that point.
+  a.clear();
+  const meta = {ctrlKey: false, metaKey: true, target: {tagName: 'BODY'}};
+  a.fireDoc('keydown', Object.assign({code: 'MetaLeft', key: 'Meta'}, meta));
+  a.fireDoc('keydown', Object.assign({code: 'KeyS', key: 's'}, meta));
+  a.fireDoc('keyup', Object.assign({code: 'MetaLeft', key: 'Meta'}, meta));   // and no keyup for S
+  const stuck = a.keys().filter(k => k === '+KeyS').length - a.keys().filter(k => k === '-KeyS').length;
+  check(stuck === 0, 'a key held under Command is not left down', a.keys().join(' '));
+
+  // Before the emulator has been started there is nothing to type at.
+  const b = buildPage();
+  b.fireDoc('keydown', {code: 'KeyG', key: 'g', target: {tagName: 'BODY'}});
+  check(b.posted.length === 0, 'keys before the machine starts are not queued up', JSON.stringify(b.types()));
+}
+
+// ---- 9. the floating controls ----------------------------------------------
+{
+  const a = buildPage();
+  a.start();
+  const joy = pointer(a.el('move-gesture-zone'), 1, 'mouse');
+  joy.down(80, 80);
+  joy.move(80, 20);              // straight up
+  const pressed = a.keys().join(' ');
+  joy.up(80, 20);
+  check(pressed.includes('+Numpad8'), 'the joystick works under a mouse', pressed || 'nothing');
+  check(a.keys().join(' ').includes('-Numpad8'), 'and lets go when the drag ends', a.keys().join(' '));
+
+  a.clear();
+  const stroke = pointer(a.el('action-gesture-zone'), 2, 'mouse');
+  stroke.down(20, 20);
+  for (let y = 20; y <= 120; y += 20) stroke.move(20, y);     // down
+  for (let x = 20; x <= 120; x += 20) stroke.move(x, 120);    // then right: an L
+  stroke.up(120, 120);
+  a.tick(100);
+  check(a.keys().join(' ') === '+KeyL -KeyL', 'a gesture can be drawn with a mouse', a.keys().join(' ') || 'nothing');
+}
+
+// ---- 10. the screen size comes from the emulator ---------------------------
+{
+  const a = buildPage();
+  a.start();
+  a.screen(800, 600);
+  pointer(a.el('touch-overlay'), 1, 'mouse').move(VIEW_W / 2, VIEW_H / 2);
+  const m = a.lastMove();
+  check(!!m && near(m.x, 400) && near(m.y, 300),
+        'coordinates follow the resolution the emulator reports', m ? `(${m.x}, ${m.y}) of 800x600` : 'nothing');
+  const inBounds = a.moves().every(p => p.x >= 0 && p.x < 800 && p.y >= 0 && p.y < 600);
+  check(inBounds, 'the pointer is never sent off the emulated screen');
+}
+
+console.log(failures ? `\nFAIL — ${failures} problem(s)` : '\ninput check: clean');
+process.exit(failures ? 1 : 0);

--- a/cythera/utilities/mobile_undither_check.mjs
+++ b/cythera/utilities/mobile_undither_check.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Checks mobile.html's undither shader against the viewer it was taken from.
+//
+//   node utilities/mobile_undither_check.mjs mobile.html cythera_data_viewer.html
+//
+// cythera_data_viewer.html owns this filter. Its UD block is the settled
+// result of the tuning done in cythera_graphics_undither.html, and mobile.html
+// runs the same filter on the emulator's live screen -- as three GPU passes,
+// because the viewer's implementation costs 5.8 seconds for a 640x480 frame
+// and 16 seconds at phone resolution. Two copies of one filter is exactly the
+// arrangement where a tuning change lands in one of them and not the other.
+//
+// So this reads the settings and the detector's constants out of the viewer
+// and fails if the shader has drifted from them. What it cannot do here is
+// compare output: that needs a GL context. The port was measured against the
+// viewer's own undither() in headless Chromium, over a checkerboard-dithered
+// gradient crossed by one-pixel linework, with stray repair and the 2x
+// supersample switched off in the reference to match what the shader carries:
+//
+//   mean |difference| 0.035 of 255, worst case 1, borders included.
+//
+// Re-measure that after any change to the maths, not just this.
+
+import {readFileSync, existsSync} from 'node:fs';
+
+const [mobilePath = 'mobile.html', viewerPath = 'cythera_data_viewer.html'] = process.argv.slice(2);
+for (const p of [mobilePath, viewerPath]) {
+  if (!existsSync(p)) { console.error('missing: ' + p); process.exit(2); }
+}
+const mobile = readFileSync(mobilePath, 'utf8');
+const viewer = readFileSync(viewerPath, 'utf8');
+
+let failures = 0;
+const fail = (what, detail) => { failures++; console.log('  FAIL ' + what + (detail ? ' — ' + detail : '')); };
+const ok = (what, detail) => console.log('  ok   ' + what + (detail ? ' — ' + detail : ''));
+const check = (cond, what, detail) => cond ? ok(what, detail) : fail(what, detail);
+
+// ---- the viewer's settings -------------------------------------------------
+const udSrc = (() => {
+  const at = viewer.indexOf('const UD = {');
+  if (at < 0) { console.error('no UD block in ' + viewerPath); process.exit(2); }
+  return viewer.slice(at, viewer.indexOf('};', at));
+})();
+const ud = {};
+for (const m of udSrc.matchAll(/(\w+)\s*:\s*("[^"]*"|[\d.]+|true|false)/g)) {
+  ud[m[1]] = m[2] === 'true' ? true : m[2] === 'false' ? false
+           : m[2].startsWith('"') ? m[2].slice(1, -1) : Number(m[2]);
+}
+console.log(`  viewer UD: sens ${ud.sens}, strength ${ud.strength}, detail ${ud.detail}, ` +
+            `filter ${ud.filter}, passes ${ud.passes}, radius ${ud.radius}`);
+
+// ---- what the page carries -------------------------------------------------
+const settingsSrc = /const UNDITHER = \{([^}]*)\}/.exec(mobile);
+if (!settingsSrc) { fail('settings block', 'no `const UNDITHER = {...}` in ' + mobilePath); }
+const settings = {};
+if (settingsSrc) for (const m of settingsSrc[1].matchAll(/(\w+)\s*:\s*([\d.]+)/g)) settings[m[1]] = Number(m[2]);
+
+for (const key of ['sens', 'strength', 'detail']) {
+  check(settings[key] === ud[key], `${key} matches the viewer`, `${settings[key]} vs ${ud[key]}`);
+}
+
+// ---- the shader source -----------------------------------------------------
+function shader(name) {
+  const at = mobile.indexOf(`const ${name} = \``);
+  if (at < 0) return null;
+  return mobile.slice(mobile.indexOf('`', at) + 1, mobile.indexOf('`;', at));
+}
+const inside = shader('GLSL_INSIDE');
+const shaders = {};
+for (const name of ['VS', 'FS_MEAN', 'FS_DETECT', 'FS_DETAIL']) {
+  const src = shader(name);
+  if (src === null) { fail('shader ' + name, 'not found'); continue; }
+  shaders[name] = inside ? src.replace(/\$\{GLSL_INSIDE\}/g, inside) : src;
+}
+// A `${}` left unresolved compiles to nothing but a syntax error at run time,
+// on a path only reached when someone turns the filter on.
+const unresolved = Object.entries(shaders).filter(([, src]) => /\$\{/.test(src)).map(([n]) => n);
+check(unresolved.length === 0, 'every shader interpolates', unresolved.join(', ') || '4 shaders');
+
+const detect = shaders.FS_DETECT || '';
+
+// ---- the detector's constants, as the viewer states them -------------------
+// detect() in the viewer: a residual below 0.5 is nothing; coherence is turned
+// into a weight by (thr - coh) * 8; the weight is faded in over a residual
+// magnitude of 1.5 to 5.0; the line reach is 3 pixels along each axis.
+const viewerDetect = viewer.slice(viewer.indexOf('function detect('), viewer.indexOf('function checkerNotch('));
+const wanted = [
+  [/const LINE_REACH\s*=\s*(\d+)/.exec(viewer)?.[1], /k\s*<=\s*(\d+)/.exec(detect)?.[1], 'line reach'],
+  [/\(thr-coh\)\*(\d+)/.exec(viewerDetect.replace(/\s/g, ''))?.[1],
+   /u_sens\s*-\s*coh\)\s*\*\s*([\d.]+)/.exec(detect)?.[1]?.replace(/\.0$/, ''), 'coherence-to-weight slope'],
+];
+for (const [want, got, label] of wanted) {
+  check(want !== undefined && String(want) === String(got), label, `viewer ${want}, shader ${got}`);
+}
+const smoothViewer = /smoothstep\(([\d.]+),([\d.]+),m\)/.exec(viewerDetect.replace(/\s/g, ''));
+const smoothShader = /smoothstep\(([\d.]+),\s*([\d.]+),\s*m\)/.exec(detect);
+check(smoothViewer && smoothShader && smoothViewer[1] === smoothShader[1] && smoothViewer[2] === smoothShader[2],
+      'the magnitude ramp', smoothViewer && smoothShader ? `viewer ${smoothViewer[1]}-${smoothViewer[2]}, shader ${smoothShader[1]}-${smoothShader[2]}` : 'not found');
+check(/m\s*>=\s*0\.5/.test(detect) && /mj\s*<\s*0\.5/.test(detect), 'the residual floor of 0.5');
+check(ud.diagonals === false && /a\s*<\s*2/.test(detect), 'two axes, as the viewer has diagonals off');
+
+// ---- the smoother ----------------------------------------------------------
+// checkerNotch is half the pixel and half the mean of its four orthogonal
+// neighbours. It ignores its guide argument, which is why the viewer's
+// `passes: 3` computes the same answer three times over.
+check(ud.filter === 'notch', 'the viewer still uses the notch smoother', String(ud.filter));
+check(/0\.5\s*\*\s*c\s*\+\s*0\.5\s*\*/.test(detect), 'the notch is half and half');
+check(/for\s*\(int e = 0; e < 4; e\+\+\)/.test(detect), 'over four orthogonal neighbours');
+
+// ---- the stages the page deliberately leaves out ---------------------------
+// mobile.html explains why it does not carry these. If the viewer ever turns
+// one off, that explanation is stale and the shader may be able to gain it.
+check(ud.stray > 0, 'the viewer still does stray-colour repair (the page explains why it does not)',
+      'stray ' + ud.stray);
+check(ud.upscale === 2 && ud.supersample === true,
+      'the viewer still supersamples (the page explains why it does not)',
+      `upscale ${ud.upscale}, supersample ${ud.supersample}`);
+check(/deliberately not here/.test(mobile), 'the page still explains both');
+
+console.log(failures ? `\nFAIL — ${failures} problem(s)` : '\nundither check: clean');
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
The page drove the emulator from `touchstart`/`touchmove`/`touchend` only.
#touch-overlay is stretched across the emulator's iframe so that it can
catch touches, so it also caught every click -- and it listened for nothing
a mouse produces. On a desktop the emulator was on screen, visibly running,
and could not be clicked or typed at at all. The name said mobile; the
overlay made it mobile-only.

All input now goes through one pointer-event path, so a finger, a stylus and
a mouse take the same route:

- A mouse points: it is always Direct, moves the emulated cursor while
  hovering (menus highlight, the cursor changes shape), sends both buttons
  as themselves, and the wheel zooms. Trackpad mode is a way to move a
  pointer you cannot put a finger on, so a mouse ignores it; Pan View still
  applies, and there a drag moves the view.
- A physical keyboard reaches the emulated Mac. The iframe is cross-origin
  with the overlay on top of it, so it can never take focus -- keys are
  forwarded by `code`, which is what the embed API asks for. Cythera is
  played on the numeric keypad, so this is not a nicety.
- Nothing is left held. There was no touchcancel handler and no record of
  which mouse buttons were down, so a gesture the browser took over left the
  button down inside the Mac for good. Buttons are now tracked and released
  on cancel, on hide and on blur, alongside the keys. A key held under
  Command is swept up too (mihaip/infinite-mac#89): Infinite Mac works
  around that for its own keyboard, and messages sent through the embed API
  arrive past that point.
- Coordinates follow the resolution the emulator reports in emulator_screen
  rather than the size this page asked for, so the pointer still lands where
  it is aimed if the machine comes up at another resolution or the guest
  changes one. A tap is measured from where it started rather than from the
  previous move, so a slow drag no longer counts as a tap.
- The start click moves the pointer before pressing. With no move first it
  landed at 0,0 -- the corner of the menu bar -- so starting the game could
  pull down the Apple menu.
- The joystick, the gesture strokes and every control in the settings drawer
  work under a mouse, and take Enter/Space from a keyboard. The keyboard
  button listened for `touchend` alone, which a mouse never sends.

utilities/mobile_input_check.mjs is new: it drives the page's pointer, wheel
and keyboard handling in a stub DOM whose element rectangles are computed
from the CSS transforms the page itself sets, so the coordinate arithmetic
is really under test. Run against the previous version of this file it fails
fourteen ways, including every mouse and keyboard row. mobile_api_check.mjs
asks whether what the page sends is in the emulator's API; this asks whether
anything is sent at all, for each way a person can touch the thing.

Also verified in Chromium with real trusted input -- mouse, wheel, keyboard,
touch tap, window dragging -- against a stub of the infinitemac.org embed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BuirKQ7j96euZijpbEo7hs