### PR TITLE
Fold the AI-upscaled versions behind a toggle

### DIFF
--- a/cube/index.html
+++ b/cube/index.html
@@ -123,6 +123,10 @@
     }
     #help-toggle { font-weight: 700; }
 
+    /* A disclosure control, not a peer of the version buttons. */
+    #ai-toggle { font-size: 11px; letter-spacing: 0.5px; opacity: 0.6; padding: 6px 8px; }
+    #ai-toggle:hover { opacity: 1; }
+
     #help-overlay {
       position: fixed; inset: 0; background: rgba(0,0,0,0.82); z-index: 9998;
       display: flex; justify-content: center; align-items: center;
@@ -318,7 +322,7 @@
         hasDepth: false,
         versions: [
           { label: 'Original', suffix: '_orig.jpeg' },
-          { label: '4K',       suffix: '_seamless.webp' }
+          { label: '4K',       suffix: '_seamless.webp', ai: true }
         ]
       },
       {
@@ -342,8 +346,8 @@
         hasDepth: false,
         versions: [
           { label: 'Original',    suffix: '-orig.jpg' },
-          { label: '2K (HD)',     suffix: '-hdmod.webp' },
-          { label: '6K',          suffix: '-seamless.webp' }
+          { label: '2K (HD)',     suffix: '-hdmod.webp', ai: true },
+          { label: '6K',          suffix: '-seamless.webp', ai: true }
         ]
       },
       {
@@ -370,6 +374,9 @@
 
     let currentLocation = locations[1];
     let currentVersionIndex = 0;
+    // `Original` is the untouched game capture; the other versions are
+    // AI-upscaled derivatives of it. They stay folded away until asked for.
+    let showAiVersions = false;
     let hasActiveDepth = false; 
     let isTransitioning = false;
     let currentLoadId = 0;
@@ -1915,8 +1922,12 @@
           uploadUI.style.display = 'none';
           qBar.innerHTML = '';
           currentLocation.versions.forEach((v, idx) => {
+            // Keep the active button on show even when collapsed, so the bar
+            // never hides the version actually on screen.
+            if (v.ai && !showAiVersions && idx !== currentVersionIndex) return;
             const btn = document.createElement('button'); btn.textContent = v.label;
             if (idx === currentVersionIndex) btn.classList.add('active');
+            if (v.ai) btn.title = 'AI-upscaled from the original capture';
             btn.onclick = () => {
               if (currentVersionIndex !== idx && !isTransitioning) {
                 currentVersionIndex = idx; updateUI(); loadPanorama('fade');
@@ -1924,6 +1935,20 @@
             };
             qBar.appendChild(btn);
           });
+
+          // Only ages that have AI versions get the toggle.
+          if (currentLocation.versions.some(v => v.ai)) {
+            const aiBtn = document.createElement('button');
+            aiBtn.id = 'ai-toggle';
+            aiBtn.textContent = showAiVersions ? 'AI \u25be' : 'AI \u25b8';
+            aiBtn.title = showAiVersions
+              ? 'Hide AI-upscaled versions'
+              : 'Show AI-upscaled versions';
+            aiBtn.setAttribute('aria-expanded', String(showAiVersions));
+            // Purely a visibility change — nothing about the loaded panorama moves.
+            aiBtn.onclick = () => { showAiVersions = !showAiVersions; updateUI(); };
+            qBar.appendChild(aiBtn);
+          }
       }
     }
 


### PR DESCRIPTION
The quality bar rendered every entry in `versions` flat, so `Original` — the untouched game capture — sat beside its AI-upscaled derivatives with nothing marking the difference: Amateria's `4K`, and J'nanin's `2K (HD)` and `6K`.

Those three are now flagged `ai: true` and hidden behind an `AI` disclosure button appended to the bar. Voltaic and Edanna have no derived versions, so they get no toggle and their bar is unchanged.

| age | collapsed | expanded |
| --- | --- | --- |
| Amateria | `Original` `AI ▸` | `Original` `4K` `AI ▾` |
| Voltaic | `Original` | — no toggle |
| J'nanin | `Original` `AI ▸` | `Original` `2K (HD)` `6K` `AI ▾` |
| Edanna | `Original` | — no toggle |

Two details worth keeping:

- The **active button always renders**, even when collapsed and even if it is an AI version. Otherwise the bar would hide the version actually on screen and misreport what you are looking at. Selecting `6K` then collapsing leaves `Original` `6K*`.
- The expanded state lives outside the per-location render, so it **survives switching age** rather than resetting each time.

Toggling only changes visibility — nothing about the loaded panorama moves, so there is no reload.

A fullscreen toggle was also requested, but one already exists on `main` and is wired up correctly, so nothing was needed there. Verified it still enters and exits.

## Verification

Driven in Chromium against a local server: all four ages behave as tabulated above; the smoke run reports no page errors, no failed requests, and the mid-transition guard holding.

One note on testing — the first harness run appeared to show Amateria missing its toggle. That was the harness racing the initial load: the viewer correctly refuses a location change mid-transition and reverts the dropdown. The test now waits for the selection to stick and the loader to clear.

Only `cube/index.html` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNkFRjfT5jE5AantKjhJkv)_