### PR TITLE
Make the creatures legible, bake the slug off, add a lasso

### DIFF
--- a/cythera/colorcyclecanvas.html
+++ b/cythera/colorcyclecanvas.html
@@ -169,6 +169,15 @@ button{font:inherit; color:inherit}
   stroke-linecap:round; stroke-linejoin:round; overflow:visible}
 .fx[aria-pressed="true"]{background:var(--aqua); border-color:var(--aqua); color:var(--aqua-ink)}
 .fx svg *{transform-box:fill-box; transform-origin:center}
+/* A creature's name and what it does, floated over whatever is under the row
+   rather than pushed into the layout -- on a phone there is no hover to read
+   a title with, and nothing here may change the height of the rail. */
+.grp.fxGrp{position:relative}
+.fxTip{position:absolute; left:0; right:0; top:calc(100% - 1px); z-index:34;
+  padding:7px 9px; border:1px solid var(--line); border-radius:4px; background:var(--raise);
+  box-shadow:var(--shadow); font-size:11.5px; line-height:1.32; color:var(--muted)}
+.fxTip[hidden]{display:none}
+.fxTip b{display:block; margin-bottom:1px; font-size:12px; font-weight:600; color:var(--ink)}
 @media (prefers-reduced-motion:no-preference){
   .fx svg .bob{animation:fxBob 3.4s ease-in-out infinite}
   .fx svg .wag{animation:fxWag 3.0s ease-in-out infinite}
@@ -300,31 +309,37 @@ code{font-family:"DM Mono",monospace; font-size:.92em; color:var(--ink-2)}
 
   .main{display:flex; flex-direction:column; min-height:0}
   .pane{order:1; flex:1 1 auto; min-height:0; padding:6px 8px; gap:5px}
-  /* The sheet may never take more than this, whatever is open inside it --
-     the painting stays on screen and the settings scroll within their share. */
+  /* The strip along the bottom holds only the tool, the creatures and the ink,
+     and it is always the same height. Everything else opens as a panel *over*
+     the picture rather than under it, so going looking for an option never
+     shrinks the canvas -- which is what made the settings unusable before. */
   .rail{order:2; flex:0 0 auto; border-right:0; border-top:1px solid var(--line);
-    padding:8px 10px 10px; overflow:hidden; max-height:62dvh;
+    padding:8px 10px 10px; overflow:visible; max-height:none; position:relative;
     display:flex; flex-direction:column}
 
-
-  /* pinch does the zooming on a phone, and the rate box can wait until the
-     settings sheet is shut -- the picture matters more than either. */
-  .zoomBox{display:none}
-  body.sheet .rateBox{display:none !important}
-  body.sheet .status{display:none}
+  /* pinch does the zooming on a phone, and the later .zoomBox rule would
+     otherwise win this on source order -- media queries carry no weight */
+  .zoomBox{display:none !important}
   /* the live tool, the way to another, and the creatures: all reachable */
-  .toolNow{padding:6px 8px 10px}
+  .toolNow{padding:5px 8px 9px}
   /* sideways there is no height to spare, so the creatures go on one line */
   .fxRow{grid-template-columns:repeat(8,minmax(0,1fr))}
-  .fx{padding:5px 0}
-  .fx svg{width:21px; height:21px}
+  .fx{padding:4px 0}
+  .fx svg{width:20px; height:20px}
+  /* A heading costs a whole line each and the row under it already says what
+     it is: eight creatures, and a ramp or a colour. The picture gets the
+     three lines back. */
+  .fxGrp > .hd, .inkGrp > .hd{display:none}
+  /* the rail's height is fixed, so nothing in it may appear and disappear;
+     what a tool does is in the Tools picker, where there is room for it */
   .toolhelp{display:none; margin-top:6px}
-  body.sheet .toolhelp{display:block}
   .mobOnly{display:inline-flex}
 
   /* the ink stays out too, on one line */
-  .grp{margin-bottom:8px}
-  .grp .hd{margin-bottom:4px}
+  .rail{padding:6px 9px 8px}
+  .grp{margin-bottom:6px}
+  .grp:last-child{margin-bottom:0}
+  .grp .hd{margin-bottom:3px}
   #inkRampBox{display:flex; gap:6px; align-items:center; flex-wrap:wrap; margin-top:6px}
   /* an ID beats [hidden], so say it again */
   #inkRampBox[hidden]{display:none}
@@ -334,13 +349,27 @@ code{font-family:"DM Mono",monospace; font-size:.92em; color:var(--ink-2)}
   /* Only the settings scroll. The tool strip and the ink cannot be scrolled
      out of sight, which is what made it unclear which tool was even active. */
   .sheetScroll{display:none}
-  body.sheet .sheetScroll{display:block; flex:1 1 auto; min-height:0; overflow-y:auto; padding-top:2px}
+  body.sheet .sheetScroll{display:block; position:absolute; left:0; right:0; bottom:100%;
+    z-index:32; max-height:min(46dvh,360px); overflow-y:auto; padding:8px 10px 12px;
+    background:var(--surface); border-top:1px solid var(--line);
+    border-bottom:1px solid var(--line); box-shadow:0 -14px 34px -20px rgba(0,0,0,.85)}
+  body.sheet .sheetScroll .grp:last-child{margin-bottom:0}
 
   .transport{gap:5px}
   .transport .btn{padding:5px 9px}
   .status{font-size:10px; gap:9px}
   .status span:nth-child(n+4){display:none}
-  .paperWrap{padding:0}
+  /* The picture hugs the top of its pane rather than floating in the middle
+     of it: a wide canvas leaves its spare height all in one place, at the
+     bottom, which is exactly where the settings panel opens. */
+  .paperWrap{padding:0; align-items:flex-start}
+  /* and the settings themselves are laid out tightly, so the panel is short
+     enough to leave the picture showing above it */
+  label.fld{margin-top:7px}
+  label.fld > span{font-size:11px}
+  input[type=range]{height:16px}
+  .chk{margin-top:7px}
+  .selActs{margin-top:6px}
   dialog{max-width:96vw}
   .pal{grid-template-columns:repeat(12,1fr)}
 }
@@ -351,7 +380,9 @@ code{font-family:"DM Mono",monospace; font-size:.92em; color:var(--ink-2)}
   .pane{order:1; flex:1 1 auto; min-width:0}
   .rail{order:2; flex:0 0 clamp(230px,38vw,300px); max-height:none; min-height:0;
     border-top:0; border-left:1px solid var(--line); overflow-y:auto; padding:8px 10px}
-  .sheetScroll{display:contents}
+  /* sideways everything fits at once, so the panel is not a panel */
+  .sheetScroll,body.sheet .sheetScroll{display:contents; position:static; max-height:none;
+    padding:0; background:none; border:0; box-shadow:none}
   .mobOnly{display:none}
   .toolhelp{display:none}
   .status{display:none}
@@ -536,12 +567,13 @@ code{font-family:"DM Mono",monospace; font-size:.92em; color:var(--ink-2)}
       <p class="toolhelp" id="toolhelp"></p>
     </div>
 
-    <div class="grp">
+    <div class="grp fxGrp">
       <div class="hd"><span class="eyebrow">Effects</span><span class="tag" id="fxCount"></span></div>
       <div class="fxRow" id="fxRow"></div>
+      <div class="fxTip" id="fxTip" hidden><b></b><span></span></div>
     </div>
 
-    <div class="grp">
+    <div class="grp inkGrp">
       <div class="hd"><span class="eyebrow">Ink</span></div>
       <div class="seg" id="inkSeg">
         <button type="button" data-ink="ramp" aria-pressed="true">Flow ramp</button>
@@ -600,11 +632,17 @@ code{font-family:"DM Mono",monospace; font-size:.92em; color:var(--ink-2)}
           <button type="button" data-dm="part" aria-pressed="false" title="Forces them open and fills the gap with the flat colour">Part</button>
         </div>
       </div>
-      <label class="fld" data-for="meltsteps"><span>Ramp steps <b id="vMelt">32</b></span>
-        <input type="range" id="meltN" min="2" max="256" value="32"></label>
+      <label class="fld" data-for="meltsteps"><span>Ramp colours <b id="vMelt">8</b></span>
+        <input type="range" id="meltN" min="2" max="256" value="8"></label>
+      <div class="fld" data-for="meltpour"><label class="chk"><input type="checkbox" id="meltPour" checked>
+        Set what you melted turning</label>
+        <p class="rh" style="margin:5px 0 0">The colours you drag across are handed to the new ramp, so
+          the gradient you melted starts cycling where it stands. Off, the ramp is made and loaded into
+          the ink but the picture is left alone.</p></div>
       <div class="fld" data-for="selmode"><span class="eyebrow lbl">Select by</span>
         <div class="seg" id="selSeg">
           <button type="button" data-sm="box" aria-pressed="true" title="Drag out a rectangle">Box</button>
+          <button type="button" data-sm="lasso" aria-pressed="false" title="Draw freehand round what you want — let go and it closes">Lasso</button>
           <button type="button" data-sm="region" aria-pressed="false" title="Click and it takes the joined-up area of that colour">Region</button>
         </div>
         <div class="selActs">
@@ -756,20 +794,25 @@ code{font-family:"DM Mono",monospace; font-size:.92em; color:var(--ink-2)}
       moving gradient. Nothing crosses over: a tool holding a ramp never reaches for the flat colour,
       and a tool holding a colour never reaches for a ramp. <strong>Melt</strong> is what picking means
       when the ink is a ramp &mdash; one pixel cannot describe a gradient, so it collects a run of them
-      and strings them into one.</p>
+      and strings them into one. It then <em>pours it back</em>: every still pixel that was part of that
+      gradient is handed the matching step of the new ramp, so what you melted starts turning where it
+      stands. Eight colours by default &mdash; the width of one of Cythera's own registers.</p>
     <p><strong>Tools come in three kinds</strong>, and the rail shows one button for each thing you
       might actually want. <em>Create</em> puts new ink down; <em>modify</em> works on what is already
       there; <em>effects</em> are not tools at all but toggles that stay on and bend the whole studio
       while you go on working. Everything that is not painting &mdash; registers, the palette, the
       canvas size, the theme &mdash; is behind <strong>Setup</strong>.</p>
-    <p><strong>Select confines everything.</strong> Drag out a box, or take a whole joined-up area with
+    <p><strong>Select confines everything.</strong> Drag out a box, draw freehand round something with
+      Lasso, or take a whole joined-up area with
       Region, and from then on every tool, every fill and every creature works inside it and nowhere
       else &mdash; because a selection is a mask, and the one place paint is written checks it. Cut,
       copy and paste keep the shape you selected rather than a rectangle around it, and dragging from
       inside a selection carries its contents with it.</p>
     <h4>The creatures</h4>
     <p><strong>Giant Slug</strong> chains every turning register into one long body, so colour leaving
-      the end of Fire arrives at the start of Water; switch it off and they come apart again.
+      the end of Fire arrives at the start of Water. Switch it off and every pixel keeps the colour it
+      is showing at that moment &mdash; the joins the slug made are broken exactly where they stand,
+      which is how you get a picture the separate registers could never have reached on their own.
       <strong>Hydra Polyp</strong> takes a tool at random once a second and uses it at random.
       <strong>Ratlizard</strong> gnaws every edge in the picture a pixel at a time.
       <strong>Chicken</strong> pecks your strokes into scattered grain. <strong>Crab</strong> walks
@@ -1500,6 +1543,32 @@ function frameMap(f) {
   _mapF = f; _map = m; return m;
 }
 function invalidateMap() { _mapF = -1; }
+/* Switching Giant Slug or Skeleton changes what every palette entry reads as,
+ * so the picture would otherwise jump. Instead the change is *baked*: each
+ * pixel is handed whichever index shows, under the new arrangement, the colour
+ * it was showing under the old one. Turning the slug off therefore leaves the
+ * colours exactly where they had got to and breaks the joins it made -- a run
+ * that had wandered out of Fire and into Water genuinely lives in Water now,
+ * and the two go back to turning separately from there.
+ */
+function bakeCycling(change) {
+  var before = frameMap(frame % LOOP).slice();     // a copy: the cache is reused in place
+  change();
+  invalidateMap(); rebuildLoop();
+  frame = ((frame % LOOP) + LOOP) % LOOP;
+  var after = frameMap(frame % LOOP), i, same = true;
+  for (i = 0; i < PAL.length; i++) if (before[i] !== after[i]) { same = false; break; }
+  if (same) return;
+  var inv = new Int32Array(PAL.length).fill(-1);
+  for (i = 0; i < PAL.length; i++) { var t = after[i]; if (t >= 0 && t < PAL.length) inv[t] = i; }
+  snapshot();
+  for (var q = 0; q < idx.length; q++) {
+    var v = idx[q];
+    if (!v || v >= PAL.length) continue;
+    var to = inv[before[v]];
+    if (to > 0) idx[q] = to;
+  }
+}
 
 /* Switching depth rebuilds the base palette and re-snaps the picture through
  * it. A ramp is a run of colours, not a set of CLUT offsets, so every ramp
@@ -1704,15 +1773,17 @@ function place(x, y, v) {
   if (x < 0 || x >= W || y < 0 || y >= H) return;
   var i = y * W + x;
   if (sel && !sel[i]) return;
-  if (FX.ghost && idx[i] && bay(x + 2, y + 1) > 0.66) return;
+  // in 2x2 blocks, so the pattern reads as tatters at any size rather than
+  // disappearing into a single-pixel dither
+  if (FX.ghost && idx[i] && bay((x >> 1) + 2, (y >> 1) + 1) > 0.5) return;
   idx[i] = v;
 }
 function lay(x, y, v) {
   if (opacity < 100 && bay(x, y) >= opacity / 100) return;
   if (FX.chicken) {                              // pecked into grains, and scattered
-    if (hash2(x * 13 + 5, y * 7 + 3) > 0.6) return;
-    var jx = x + (hash2(x * 3 + 11, y * 5 + 2) * 3 | 0) - 1;
-    y = y + (hash2(x * 5 + 7, y * 3 + 13) * 3 | 0) - 1;
+    if (hash2(x * 13 + 5, y * 7 + 3) > 0.5) return;
+    var jx = x + (hash2(x * 3 + 11, y * 5 + 2) * 5 | 0) - 2;
+    y = y + (hash2(x * 5 + 7, y * 3 + 13) * 5 | 0) - 2;
     x = jx;
   }
   place(x, y, v);
@@ -1756,6 +1827,10 @@ function dab(cx, cy, dx, dy, arc) {
         along += amt() * lam * 0.5 * ((fbm(x * ws, y * ws) - 0.5) * 2 +
                                       (fbm(x * ws * 2.3 + 19, y * ws * 2.3 + 7) - 0.5) * 0.55);
       }
+      // The crab's rungs: with the bands already turned across the drag, the
+      // phase is stepped rather than slid, so what comes out is a ladder and
+      // not merely the same current laid the other way round.
+      if (FX.crab) along = Math.round(along / (lam / 3)) * (lam / 3);
       var k = -(along * ramp.len / lam);
       if (reverse) k = -k;
       k += turb * (fbm(perp * 0.9, along * 0.17) - 0.5) * 2;
@@ -1824,12 +1899,18 @@ function divert(cx, cy, dx, dy, src) {
  * becomes a stop. Let go and those stops are strung into a ramp, quantised
  * to the current depth, switched on and loaded into the ink.
  */
-var meltStops = [], meltMoved = false, meltSteps = 32;
-var MELT_MAX = 24;
+var meltStops = [], meltTook = [], meltMoved = false, meltSteps = 8, meltFlow = true;
+var MELT_MAX = 24, MELT_TOOK_MAX = 160;
 function meltSample(x, y) {
   var v = idx[y * W + x];
   if (!v) return;
-  var c = PAL[v]; if (!c) return;
+  // Every still slot the cursor crosses is noted, whether or not it earns a
+  // stop of its own -- those are the exact colours that will be handed over to
+  // the ramp afterwards, so nothing the drag never touched is ever disturbed.
+  if (rlut(v) < 0 && meltTook.indexOf(v) < 0 && meltTook.length < MELT_TOOK_MAX) meltTook.push(v);
+  // what the pixel is *showing* this frame, not what its slot holds: melting
+  // is done by eye, and a pixel inside a turning register is not its own index
+  var c = PAL[frameMap(frame % LOOP)[v]]; if (!c) return;
   if (meltStops.length >= MELT_MAX) return;
   // A dithered picture flips colour every other pixel, so a colour has to be
   // properly unlike everything already collected before it earns a stop.
@@ -1842,12 +1923,49 @@ function meltSample(x, y) {
 }
 function meltFinish() {
   if (meltStops.length < 2) return;
+  if (meltFlow) snapshot();                        // only pouring it back touches pixels
   var cols = rampFromStops(meltStops, Math.max(2, Math.min(4096, meltSteps)));
   var r = makeRamp(cols, 'Melt ' + (CUSTOM.length + 1), 'melted off the picture');
   ramp = r; setInk('ramp');
-  meltStops = [];
+  var got = meltFlow ? meltPour(r, meltTook) : 0;
+  meltStops = []; meltTook = [];
   paintRegs(); paintRamps(); paintPal(); sync(); draw();
-  say('made a ' + r.len + '-step ramp — it is the ink now');
+  say('melted a ' + r.len + '-colour ramp' +
+      (got ? ' — ' + got + ' pixels are turning now' : ' — it is the ink now'));
+}
+/* Melting is only half done when the ramp exists: what you dragged across is
+ * still standing there. Every *still* pixel near enough to the new gradient is
+ * handed the step of it that matches, so the thing you melted starts moving
+ * where it stands. Paint already inside a turning register is left alone --
+ * it is somebody else's, and it is already going. A selection confines this
+ * like it confines everything.
+ */
+function meltPour(r, took) {
+  // Exactly the slots the cursor went over, and nothing else: each is handed
+  // whichever step of the new ramp it is nearest, so what you dragged across
+  // starts turning and the rest of the picture is left where it stands. It is
+  // an indexed palette, so a colour taken here turns everywhere it is used --
+  // which is how cycling has always worked.
+  var to = {}, got = 0, i, k;
+  for (i = 0; i < took.length; i++) {
+    var v = took[i];
+    if (rlut(v) >= 0 || v >= r.base) continue;     // taken over since, or the ramp itself
+    var c = PAL[v] || [0, 0, 0], best = 0, bd = Infinity;
+    for (k = 0; k < r.len; k++) {
+      var p = PAL[r.base + k];
+      var dd = (p[0] - c[0]) * (p[0] - c[0]) + (p[1] - c[1]) * (p[1] - c[1]) +
+               (p[2] - c[2]) * (p[2] - c[2]);
+      if (dd < bd) { bd = dd; best = k; }
+    }
+    to[v] = r.base + best;
+  }
+  for (var q = 0; q < idx.length; q++) {
+    var w = to[idx[q]];
+    if (w === undefined) continue;
+    if (sel && !sel[q]) continue;
+    idx[q] = w; got++;
+  }
+  return got;
 }
 function rampFromStops(stops, n) {
   var out = [];
@@ -2017,6 +2135,45 @@ function selRect(ax, ay, bx, by) {
   return m;
 }
 function selAll() { sel = new Uint8Array(W * H).fill(1); drawSel(); refreshTool(); say('everything selected'); }
+/* The lasso. The path is closed back to where it started and filled by the
+ * even-odd rule, scanline by scanline; the outline itself is added afterwards
+ * so a scribble too thin to enclose anything still takes the pixels it
+ * actually crossed rather than nothing at all.
+ */
+var lasso = null;
+function polyMask(pts) {
+  var m = new Uint8Array(W * H), n = pts.length, i, j, x;
+  if (n < 2) { 
+    if (n === 1 && pts[0][0] >= 0 && pts[0][0] < W && pts[0][1] >= 0 && pts[0][1] < H)
+      m[pts[0][1] * W + pts[0][0]] = 1;
+    return m;
+  }
+  var xs = [];
+  for (var y = 0; y < H; y++) {
+    var cy = y + 0.5;
+    xs.length = 0;
+    for (i = 0, j = n - 1; i < n; j = i++) {
+      var ay = pts[j][1] + 0.5, by = pts[i][1] + 0.5;
+      if ((ay > cy) === (by > cy)) continue;
+      xs.push(pts[j][0] + (pts[i][0] - pts[j][0]) * (cy - ay) / (by - ay));
+    }
+    if (xs.length < 2) continue;
+    xs.sort(function (a, b) { return a - b; });
+    for (var k = 0; k + 1 < xs.length; k += 2) {
+      var x0 = Math.max(0, Math.ceil(xs[k])), x1 = Math.min(W - 1, Math.floor(xs[k + 1]));
+      for (x = x0; x <= x1; x++) m[y * W + x] = 1;
+    }
+  }
+  for (i = 0; i < n; i++) {                        // the line the hand actually drew
+    var a = pts[i], b = pts[(i + 1) % n];
+    var L = Math.max(1, Math.round(Math.hypot(b[0] - a[0], b[1] - a[1])));
+    for (var s = 0; s <= L; s++) {
+      var px = Math.round(a[0] + (b[0] - a[0]) * s / L), py = Math.round(a[1] + (b[1] - a[1]) * s / L);
+      if (px >= 0 && px < W && py >= 0 && py < H) m[py * W + px] = 1;
+    }
+  }
+  return m;
+}
 // Cut and copy keep the mask, not just the box, so a region lifted out of a
 // picture pastes back with its own outline rather than a rectangle of it.
 function selCopy(quietly) {
@@ -2128,6 +2285,7 @@ function begin(x, y) {
       selDrag = { move: 1, x0: x, y0: y, px: idx.slice(), mask: sel.slice() };
     } else {
       selDrag = { move: 0, x0: x, y0: y };
+      lasso = selMode === 'lasso' ? [[x, y]] : null;
       sel = null; drawSel();
     }
     stroking = true; startX = x; startY = y; return;
@@ -2143,6 +2301,11 @@ function extend(x, y) {
   if (!stroking) return;
   if (tool === 'select') {
     if (selDrag && selDrag.move) selMoveTo(x - selDrag.x0, y - selDrag.y0);
+    else if (lasso) {
+      var lp = lasso[lasso.length - 1];
+      if (lp[0] !== x || lp[1] !== y) lasso.push([x, y]);
+      sel = polyMask(lasso);
+    }
     else sel = selRect(selDrag.x0, selDrag.y0, x, y);
     drawSel(); draw(); return;
   }
@@ -2189,7 +2352,7 @@ function end() {
     // A tap rather than a drag means "select nothing", which is how you get
     // the whole canvas back without hunting for a button.
     if (selDrag && !selDrag.move && b && b.x0 === b.x1 && b.y0 === b.y1) { sel = null; b = null; say('selection cleared'); }
-    selDrag = null; drawSel(); refreshTool();
+    selDrag = null; lasso = null; drawSel(); refreshTool();
     if (b) say('selected ' + (b.x1 - b.x0 + 1) + '×' + (b.y1 - b.y0 + 1));
   }
   stroking = false; baseCopy = null;
@@ -2235,6 +2398,9 @@ function gestureState() {
 }
 art.addEventListener('pointerdown', function (e) {
   e.preventDefault();
+  // The settings panel floats over the picture; a touch on the picture is how
+  // you dismiss it, and that touch is not also a stroke.
+  if (!pts.size && sheetOpen()) { setSheet(false); return; }
   pts.set(e.pointerId, { x: e.clientX, y: e.clientY });
   if (pts.size === 2) {
     if (stroking) { stroking = false; undoOnce(); }   // that first finger was not a stroke after all
@@ -2444,7 +2610,7 @@ var FXI = {
  */
 var EFFECTS = [
   { id: 'slug',    name: 'Giant Slug',
-    help: 'Chains every turning register into one long body: colour leaving the end of Fire arrives at the start of Water. Switch it off and they come apart into their own cycles again.' },
+    help: 'Chains every turning register into one long body: colour leaving the end of Fire arrives at the start of Water. Switch it off and every pixel keeps the colour it is showing — the joins it made are broken exactly where they stand, and the registers go back to turning separately from there.' },
   { id: 'hydra',   name: 'Hydra Polyp',
     help: 'Once a second it grabs a tool at random, sets it at random and uses it somewhere at random. Leave it running and it will paint over everything you own.' },
   { id: 'rat',     name: 'Ratlizard',
@@ -2490,9 +2656,9 @@ var TOOLS = [
       help: 'Floods the region you click with the one colour. Sensitivity is how far it will spread across near-enough colours; Everywhere ignores whether the pixels are joined up.' } },
   { id: 'select', cat: 'modify',
     ramp:  { name: 'Select', icon: 'select',
-      help: 'Drag out a box, or switch to Region and click to take a whole joined-up area. While anything is selected, every tool and every creature works inside it and nowhere else. Drag from inside a selection to carry its contents about.' },
+      help: 'Drag out a box, draw freehand with Lasso, or switch to Region and click to take a whole joined-up area. While anything is selected, every tool and every creature works inside it and nowhere else. Drag from inside a selection to carry its contents about.' },
     still: { name: 'Select', icon: 'select',
-      help: 'Drag out a box, or switch to Region and click to take a whole joined-up area. While anything is selected, every tool and every creature works inside it and nowhere else. Drag from inside a selection to carry its contents about.' } },
+      help: 'Drag out a box, draw freehand with Lasso, or switch to Region and click to take a whole joined-up area. While anything is selected, every tool and every creature works inside it and nowhere else. Drag from inside a selection to carry its contents about.' } },
   { id: 'pick', cat: 'modify',
     ramp:  { name: 'Melt', icon: 'melt',
       help: 'Taking a ramp off the picture, which is what picking means when the ink is a ramp. Drag a line and every new colour it crosses becomes a stop; let go and they are strung into a ramp and loaded into the ink.' },
@@ -2513,7 +2679,7 @@ var USES = {
   pool:   { ramp: ['brush', 'opacity', 'fillstyle', 'lam', 'turb', 'spin', 'global'],
             still: ['brush', 'opacity', 'global'] },
   select: { ramp: ['selmode', 'brush', 'global'], still: ['selmode', 'brush', 'global'] },
-  pick:   { ramp: ['meltsteps'], still: [] }
+  pick:   { ramp: ['meltsteps', 'meltpour'], still: [] }
 };
 /* The picker is the only place all seven live, split by family. */
 (function () {
@@ -2531,7 +2697,23 @@ var USES = {
     });
   });
 })();
-/* The creatures. */
+/* The creatures. Eight small line drawings tell you nothing on their own and
+ * a phone has no hover to read a title with, so touching one -- or switching
+ * it on -- floats its name and what it does over the row for a few seconds.
+ */
+var fxTipEl = document.getElementById('fxTip'), fxTipUntil = 0;
+function showFxTip(fx, hold) {
+  if (!fxTipEl) return;
+  fxTipEl.querySelector('b').textContent = fx.name + (FX[fx.id] ? ' — on' : '');
+  fxTipEl.querySelector('span').textContent = fx.help;
+  fxTipEl.hidden = false;
+  fxTipUntil = hold ? Date.now() + 5600 : 0;
+}
+function hideFxTip(force) {
+  if (!fxTipEl || fxTipEl.hidden) return;
+  if (!force && fxTipUntil && Date.now() < fxTipUntil) return;
+  fxTipEl.hidden = true; fxTipUntil = 0;
+}
 (function () {
   var host = document.getElementById('fxRow');
   EFFECTS.forEach(function (fx) {
@@ -2541,17 +2723,27 @@ var USES = {
     b.setAttribute('aria-label', fx.name);
     b.title = fx.name + ' — ' + fx.help;
     b.innerHTML = '<svg viewBox="0 0 24 24">' + FXI[fx.id] + '</svg>';
-    b.addEventListener('click', function () { toggleFX(fx.id); });
+    b.addEventListener('click', function () { toggleFX(fx.id); showFxTip(fx, true); });
+    b.addEventListener('pointerenter', function () { if (!fxTipUntil) showFxTip(fx, false); });
+    b.addEventListener('focus', function () { if (!fxTipUntil) showFxTip(fx, false); });
+    ['pointerleave', 'blur'].forEach(function (ev) {
+      b.addEventListener(ev, function () { hideFxTip(false); });
+    });
     host.appendChild(b);
   });
+  addEventListener('pointerdown', function (e) {
+    if (!e.target.closest || !e.target.closest('.fxGrp')) hideFxTip(true);
+  }, true);
 })();
 function toggleFX(id) {
-  FX[id] = FX[id] ? 0 : 1;
+  var flip = function () { FX[id] = FX[id] ? 0 : 1; };
+  // The two that reach into the cycling change what every colour reads as, so
+  // the switch is baked into the pixels rather than allowed to jump them.
+  if (id === 'slug' || id === 'bones') { bakeCycling(flip); gotoFrame(frame); }
+  else flip();
   var fx = EFFECTS.filter(function (e) { return e.id === id; })[0];
   var b = document.querySelector('.fx[data-fx="' + id + '"]');
   if (b) b.setAttribute('aria-pressed', String(!!FX[id]));
-  // The two that reach into the cycling change the length of the loop.
-  if (id === 'slug' || id === 'bones') { invalidateMap(); rebuildLoop(); gotoFrame(frame); }
   // The two that are alive get one mark in the history, not one a second.
   if ((id === 'hydra' || id === 'rat') && FX[id]) snapshot();
   var n = 0, k;
@@ -2564,7 +2756,7 @@ function setTool(t) {
   if (t !== tool) SPIN_BY[tool] = spin;
   tool = t;
   if (SPIN_BY[t] !== undefined) setSpin(SPIN_BY[t]);
-  if (t !== 'pick') { meltStops = []; }
+  if (t !== 'pick') { meltStops = []; meltTook = []; }
   [].forEach.call(document.querySelectorAll('.pickCell'), function (b) {
     b.setAttribute('aria-pressed', String(b.dataset.tool === t));
   });
@@ -2579,7 +2771,11 @@ function paintToolInk() {
   var host = document.getElementById('toolNow');
   var cv = document.getElementById('toolInk');
   if (!cv) { cv = document.createElement('canvas'); cv.id = 'toolInk'; cv.height = 1; }
-  if (!host || tool === 'pick' || tool === 'select') { if (cv.parentNode) cv.parentNode.removeChild(cv); return; }
+  // Melt loads a ramp like anything else, and seeing it turn on the button is
+  // how you know what you just took off the picture.
+  if (!host || tool === 'select' || (tool === 'pick' && !inkIsRamp())) {
+    if (cv.parentNode) cv.parentNode.removeChild(cv); return;
+  }
   if (cv.parentNode !== host) host.appendChild(cv);
   if (inkIsRamp()) { cv.width = Math.min(48, Math.max(4, ramp.len)); rampStrip(cv, ramp, frame); }
   else {
@@ -2607,7 +2803,7 @@ function refreshTool() {
   });
   var use = USES[tool][inkIsRamp() ? 'ramp' : 'still'];
   // A box does not care how alike two colours are; only Region does.
-  if (tool === 'select' && selMode === 'box')
+  if (tool === 'select' && selMode !== 'region')
     use = use.filter(function (k) { return k !== 'brush' && k !== 'global'; });
   [].forEach.call(document.querySelectorAll('.fld[data-for]'), function (l) {
     l.classList.toggle('off', use.indexOf(l.dataset.for) < 0);
@@ -2640,17 +2836,25 @@ var ratT = 0, hydraT = 0;
 function gnaw() {
   // A bite copies a neighbouring colour over this one, so an edge is eaten
   // from both sides at once and comes out chewed rather than merely thinner.
-  var tries = Math.max(80, Math.round(W * H / 12)), bites = Math.max(3, Math.round(W * H / 900)), got = 0;
+  // Every one of the four neighbours is looked at rather than a single random
+  // direction, so a try that lands on an edge always takes something -- the
+  // old one missed nineteen times in twenty and the creature looked idle.
+  var bites = Math.max(14, Math.round(W * H / 360)), tries = bites * 24, got = 0;
   for (var k = 0; k < tries && got < bites; k++) {
     var x = (Math.random() * W) | 0, y = (Math.random() * H) | 0, i = y * W + x;
     if (sel && !sel[i]) continue;
-    var d = (Math.random() * 4) | 0;
-    var nx = x + (d === 0 ? -1 : d === 1 ? 1 : 0), ny = y + (d === 2 ? -1 : d === 3 ? 1 : 0);
-    if (nx < 0 || nx >= W || ny < 0 || ny >= H) continue;
-    var n = idx[ny * W + nx];
-    if (n === idx[i]) continue;                   // not an edge; nothing to gnaw
-    if (sel && !sel[ny * W + nx]) continue;
-    idx[i] = n; got++;
+    var here = idx[i], take = -1, seen = 0;
+    for (var d = 0; d < 4; d++) {
+      var nx = x + (d === 0 ? -1 : d === 1 ? 1 : 0), ny = y + (d === 2 ? -1 : d === 3 ? 1 : 0);
+      if (nx < 0 || nx >= W || ny < 0 || ny >= H) continue;
+      var j = ny * W + nx;
+      if (sel && !sel[j]) continue;
+      if (idx[j] === here) continue;              // not an edge; nothing to gnaw
+      seen++;
+      if (Math.random() < 1 / seen) take = idx[j];
+    }
+    if (take < 0) continue;
+    idx[i] = take; got++;
   }
 }
 function hydraAct() {
@@ -2756,6 +2960,7 @@ segBind('divSeg', 'dm', function () { return divertMode; }, function (v) { diver
 document.getElementById('rev').addEventListener('change', function (e) { reverse = e.target.checked; });
 document.getElementById('ragged').addEventListener('change', function (e) { ragged = e.target.checked; });
 document.getElementById('radial').addEventListener('change', function (e) { flowRadial = e.target.checked; });
+document.getElementById('meltPour').addEventListener('change', function (e) { meltFlow = e.target.checked; });
 document.getElementById('fillAll').addEventListener('change', function (e) { fillGlobal = e.target.checked; });
 
 /* ================= ink: a ramp, or one flat colour ====================== */
@@ -3088,7 +3293,8 @@ addEventListener('keydown', function (e) {
   if (e.target.matches && e.target.matches('input,textarea,select')) return;
   // Escape and Delete want no modifier; everything else is the usual chord.
   if (!(e.metaKey || e.ctrlKey)) {
-    if (e.key === 'Escape' && sel) { e.preventDefault(); selEmpty(); say('selection cleared'); }
+    if (e.key === 'Escape' && sheetOpen()) { e.preventDefault(); setSheet(false); }
+    else if (e.key === 'Escape' && sel) { e.preventDefault(); selEmpty(); say('selection cleared'); }
     else if ((e.key === 'Delete' || e.key === 'Backspace') && sel) { e.preventDefault(); selClearPixels(); }
     return;
   }
@@ -3129,9 +3335,10 @@ function loop(t) {
   if (sel && t - antT > 110) { antT = t; ants++; drawSel(); }
   // Neither creature interrupts a stroke of your own.
   if (!stroking) {
-    if (FX.rat && t - ratT > 150) { ratT = t; gnaw(); draw(); }
+    if (FX.rat && t - ratT > 110) { ratT = t; gnaw(); draw(); }
     if (FX.hydra && t - hydraT > 1000) { hydraT = t; hydraAct(); draw(); }
   }
+  if (fxTipUntil && Date.now() > fxTipUntil) { fxTipUntil = 0; hideFxTip(true); }
   if (sayT && Date.now() - sayT > 3600) { sayEl.textContent = ''; sayT = 0; }
   requestAnimationFrame(loop);
 }
@@ -3259,20 +3466,25 @@ function setAdvanced(on) {
 })();
 
 /* ================= the phone sheet ======================================
- * Below the breakpoint the rail is a sheet under the canvas. The tool row and
- * the ink stay out of it; everything else opens only when asked, and the
- * canvas is refitted either way so it never ends up off the screen.
+ * Below the breakpoint the rail is a strip along the bottom holding the tool,
+ * the creatures and the ink -- always the same height. The settings open as a
+ * panel *over* the picture rather than under it, so the canvas keeps the size
+ * it had: nothing is refitted, nothing is squeezed, and the first touch on the
+ * picture puts the panel away instead of painting under it.
  */
+function setSheet(on) {
+  var btn = document.getElementById('bSheet');
+  document.body.classList.toggle('sheet', on);
+  if (btn) {
+    btn.setAttribute('aria-pressed', String(on));
+    btn.textContent = on ? 'Done' : 'Settings';
+  }
+}
+function sheetOpen() { return document.body.classList.contains('sheet'); }
 (function () {
   var btn = document.getElementById('bSheet');
   if (!btn) return;
-  btn.addEventListener('click', function () {
-    var on = !document.body.classList.contains('sheet');
-    document.body.classList.toggle('sheet', on);
-    btn.setAttribute('aria-pressed', String(on));
-    btn.textContent = on ? 'Done' : 'Settings';
-    requestAnimationFrame(fitCanvas);
-  });
+  btn.addEventListener('click', function () { setSheet(!sheetOpen()); });
 })();
 addEventListener('orientationchange', function () { setTimeout(fitCanvas, 250); });
 


### PR DESCRIPTION
Giant Slug now leaves the colours where they got to. Switching it -- or
Skeleton -- changes what every palette entry reads as, so the change is
baked into the pixels: each one is handed whichever index shows, under
the new arrangement, the colour it was showing under the old. Turning
the slug off therefore breaks the joins it made exactly where they
stand, and the registers go back to turning separately from there.

The other creatures could barely be told apart from nothing happening.
Ratlizard looked at all four neighbours instead of one random direction
-- it was missing nineteen tries in twenty -- and bites often enough to
watch. Ghost refuses paint in 2x2 blocks and at half strength rather
than a third, so it reads as tatters at any size. Chicken scatters twice
as far and drops half. Crab steps the phase into rungs, so a stroke
lays a ladder rather than the same current turned sideways. And touching
a creature -- or switching one on -- floats its name and what it does
over the row, which is the only way to read them on a phone.

Select gains a Lasso: freehand, closed back to where it started and
filled by the even-odd rule, with the drawn line itself added so a thin
scribble still takes what it crossed.

Melt makes eight colours by default, the width of one of Cythera's own
registers, and pours the ramp back into the picture: exactly the slots
the cursor crossed are handed the step of the new ramp they are nearest,
so what you melted starts turning where it stands. A checkbox turns that
off, it honours a selection, and it is one undo. Melt also samples what
a pixel is showing rather than what its slot holds, and the tool button
now wears the ramp it just took.

On a phone the settings were pushing the canvas out of the way. They
open as a panel over the picture instead, the picture hugs the top of
its pane so its spare height is all in one place underneath, and nothing
is refitted -- the canvas keeps the size it had. Three headings that
cost a line each are gone, the rows are tighter, and a touch on the
picture puts the panel away instead of painting under it.
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QdiCXfdF33LTjJoMX6efdM