### PR TITLE
Animated GIFs never actually animated, and solid modules ignored the maps

### DIFF
--- a/fpqr/index.html
+++ b/fpqr/index.html
@@ -524,7 +524,7 @@
                                         <div class="custom-tooltip tooltip-right">Enables dynamic visual tracking to preview global fluid logic over any selected shape.</div>
                                     </div>
                                     <label class="relative inline-flex items-center cursor-pointer m-0">
-                                        <input type="checkbox" id="anim-toggle" class="sr-only peer render-trigger">
+                                        <input type="checkbox" id="anim-toggle" class="sr-only peer">
                                         <div class="w-8 h-4 shrink-0 bg-slate-700 rounded-full peer peer-checked:bg-emerald-500 after:content-[''] after:absolute after:top-[1px] after:left-[1px] after:bg-white after:rounded-full after:h-3.5 after:w-3.5 after:transition-all peer-checked:after:translate-x-4"></div>
                                     </label>
                                 </div>

--- a/fpqr/js/app.js
+++ b/fpqr/js/app.js
@@ -331,6 +331,10 @@ const initApp = () => {
 
     E('show-naive')?.addEventListener('change', (e) => {
         E('naive-container')?.classList.toggle('hidden', !e.target.checked);
+        // renderCanvas() now skips the naive canvas while it is off screen, and
+        // 'input' has already fired by the time this runs, so the reveal has to
+        // ask for the paint itself or the panel opens on a blank canvas.
+        if (typeof renderCanvas === 'function') renderCanvas();
     });
 
     E('import-cfg-input')?.addEventListener('change', (e) => {
@@ -364,8 +368,7 @@ const initApp = () => {
                 updateImageMapVisibility();
                 updateAnimVisibility();
                 if (E('anim-toggle')?.checked) {
-                    window.animLoopId = null;
-                    dbg('cfg import: anim on, resetting loop', 'info');
+                    dbg('cfg import: anim on, starting loop if idle', 'info');
                     startAnimIfNeeded();
                 } else if (!getHasAnimatedGif()) {
                     E('export-gif-btn')?.classList.add('hidden');
@@ -393,6 +396,11 @@ const initApp = () => {
                 gifFrames = parsed.frames;
                 gifTotalTime = parsed.totalTime;
                 showToast(`Animated ${type} Map Loaded!`);
+            } else {
+                // Falling through silently is how the broken decoder went
+                // unnoticed for so long -- the map loaded, just frozen.
+                showToast(`Could not read the GIF frames — using the first frame only.`, true);
+                dbg(`${type} map GIF decode returned no frames`, 'warn');
             }
         } else if (isGif) {
             showToast("Animated GIF Support requires Chromium browsers.", true);
@@ -456,6 +464,9 @@ const initApp = () => {
                 gifFrames = parsed.frames;
                 gifTotalTime = parsed.totalTime;
                 showToast('Animated logo loaded!');
+            } else {
+                showToast('Could not read the GIF frames — using the first frame only.', true);
+                dbg('logo GIF decode returned no frames', 'warn');
             }
         } else if (isGif) {
             showToast('Animated GIF Support requires Chromium browsers.', true);
@@ -564,7 +575,6 @@ const initApp = () => {
 
     E('live-scan-toggle')?.addEventListener('change', (e) => {
         if (e.target.checked) {
-            lastValidateTime = 0;
             scanHistory = [];
             renderCanvas();
         } else {
@@ -604,11 +614,17 @@ const initApp = () => {
         renderCanvas();
     });
 
+    // The one place that starts the mesh animation. It used to be two: this
+    // handler AND the generic .render-trigger 'input' handler, which the same
+    // checkbox also matched. A click fires input then change, so both ran, both
+    // cleared window.animLoopId, and both called startAnimIfNeeded() -- leaving
+    // two rAF loops rendering the same canvas every frame for the rest of the
+    // session (three, with an animated GIF already loaded). startAnimIfNeeded()
+    // is idempotent on its own, so nothing needs to clear the guard first.
     E('anim-toggle')?.addEventListener('change', (e) => {
         dbg(`anim-toggle change: checked=${e.target.checked} | window.animLoopId=${window.animLoopId}`, 'info');
         updateAnimVisibility();
         if (e.target.checked) {
-            window.animLoopId = null;   // ← clear REAL loop guard
             dbg('Calling startAnimIfNeeded()', 'info');
             startAnimIfNeeded();
             dbg(`after startAnimIfNeeded: window.animLoopId=${window.animLoopId}`, window.animLoopId ? 'ok' : 'error');
@@ -632,13 +648,8 @@ const initApp = () => {
         if (typeof analyzeData === 'function') analyzeData();
     }));
 
-    document.querySelectorAll('.render-trigger').forEach(el => el?.addEventListener('input', (e) => {
-        if (e.target.id === 'anim-toggle' && e.target.checked) {
-            window.animLoopId = null;   // ← clear REAL loop guard
-            if (typeof startAnimIfNeeded === 'function') startAnimIfNeeded();
-        } else if (e.target.id !== 'anim-toggle') {
-            if (typeof renderCanvas === 'function') renderCanvas();
-        }
+    document.querySelectorAll('.render-trigger').forEach(el => el?.addEventListener('input', () => {
+        if (typeof renderCanvas === 'function') renderCanvas();
     }));
 
     setTimeout(() => {

--- a/fpqr/js/gif-exporter.js
+++ b/fpqr/js/gif-exporter.js
@@ -3,7 +3,17 @@ async function decodeGif(file) {
     if (!window.ImageDecoder) return null;
     try {
         const decoder = new ImageDecoder({ type: "image/gif", data: file.stream() });
+        // The track list is populated asynchronously from the stream, so
+        // selectedTrack is ALWAYS null on the line after the constructor --
+        // reading .frameCount off it threw every single time, the catch below
+        // swallowed it, and every animated GIF silently loaded as one still
+        // frame with no error shown. Await tracks.ready before touching the
+        // track, and completed before trusting frameCount, which climbs as the
+        // stream arrives.
+        await decoder.tracks.ready;
+        await decoder.completed;
         const track = decoder.tracks.selectedTrack;
+        if (!track || !track.frameCount) return null;
         const frameCount = track.frameCount;
         const frames = [];
         let totalTime = 0;
@@ -26,11 +36,18 @@ async function decodeGif(file) {
     }
 }
 
+let lastGifBlobUrl = null;
+let gifExportRunning = false;
+
 window.exportGIF = function(canvasId) {
     if (!gifWorkerUrl) { 
         showToast("GIF Engine loading...", true); 
         return; 
     }
+    // Two captures at once would fight over globalTime and produce a pair of
+    // scrambled animations.
+    if (gifExportRunning) { showToast("A GIF is already being rendered.", true); return; }
+    gifExportRunning = true;
     
     const canvas = E(canvasId);
     const progEl = E('gif-progress');
@@ -72,11 +89,18 @@ window.exportGIF = function(canvasId) {
         durationSecs = maxMs / 1000;
     }
 
-    const frames = Math.max(10, Math.round(durationSecs * fps));
+    // Every captured frame is copied into gif.js at 1024x1024 RGBA -- 4MB each,
+    // all held until the encode finishes. Taken straight from a source GIF's
+    // length that is a tab-killer: a 10s GIF asks for 250 frames (~1GB), a 20s
+    // one for 500 (~2GB). Cap the count and stretch the per-frame delay to keep
+    // the loop the right duration, just at a lower frame rate.
+    const MAX_EXPORT_FRAMES = 120;
+    const frames = Math.min(MAX_EXPORT_FRAMES, Math.max(10, Math.round(durationSecs * fps)));
     const preciseDelta = (2 * Math.PI) / frames;
     const frameDelay = Math.round((durationSecs * 1000) / frames); 
     
     let frame = 0;
+    window.isExporting = 'gif';
     const capture = () => {
         if (frame < frames) {
             globalTime = origTime + (frame * preciseDelta); 
@@ -119,13 +143,29 @@ window.exportGIF = function(canvasId) {
         } else {
             if(progTxt) progTxt.textContent = "ENCODING..."; 
             gif.on('progress', p => { if(progTxt) progTxt.textContent = `ENCODING ${Math.round(50 + p*50)}%`; });
+            gif.on('abort', () => {
+                // Without this a failed encode leaves the guard latched and the
+                // button dead until the page is reloaded.
+                gifExportRunning = false;
+                window.isExporting = false;
+                progEl?.classList.add('hidden');
+                globalTime = origTime;
+                gifTimeMs = origGifTime;
+                renderCanvas();
+                showToast('GIF encoding failed.', true);
+            });
             gif.on('finished', b => { 
                 progEl?.classList.add('hidden'); 
+                window.isExporting = false;
                 globalTime = origTime; 
                 gifTimeMs = origGifTime;
                 renderCanvas(); 
                 
+                // Released when the modal closes; a 1024px animation is several
+                // megabytes and every export was leaking one for the session.
+                if (lastGifBlobUrl) URL.revokeObjectURL(lastGifBlobUrl);
                 const blobUrl = URL.createObjectURL(b);
+                lastGifBlobUrl = blobUrl;
                 const modal = E('isolate-modal');
                 const img = E('isolate-img');
                 if(img) img.src = blobUrl;
@@ -149,6 +189,7 @@ window.exportGIF = function(canvasId) {
                     void modal.offsetWidth; 
                     modal.classList.add('opacity-100'); 
                 }
+                gifExportRunning = false;
             });
             gif.render();
         }

--- a/fpqr/js/qr-engine.js
+++ b/fpqr/js/qr-engine.js
@@ -44,8 +44,6 @@ const QR_CAPACITY = {
 let currentMatrices = null;
 
 // Live Validation Tracker
-let lastValidateTime = 0;
-let validationTimeout = null;
 let scanHistory = [];
 const validateCanvas = document.createElement('canvas');
 validateCanvas.width = 512; 
@@ -62,6 +60,10 @@ let lastAnimScanUpdate = Date.now();
 // the range the DP is actually choosing between.
 const SEG_HEADER_BITS = { numeric: 4 + 10, alphanumeric: 4 + 9, byte: 4 + 8 };
 
+// Trailing bits for a numeric run whose length is 1 or 2 past a multiple of 3.
+// Hoisted so the DP's inner loop is not re-creating it a few million times.
+const NUMERIC_TAIL_BITS = [0, 4, 7];
+
 function getBits(s, m) {
     const l = s.length; 
     if(m === 'numeric') return Math.floor(l/3)*10 + [0,4,7][l%3]; 
@@ -73,7 +75,15 @@ function extractFormatInfoFromImage(imageData, code) {
     let result = { ec: 'M', mask: -1 };
     try {
         const tl = code.location.topLeftCorner, tr = code.location.topRightCorner, bl = code.location.bottomLeftCorner;
-        const dim = code.version * 4 + 17, dist = dim - 1; 
+        // jsQR's *Corner points are the OUTER corners of the symbol, not the
+        // centres of the corner modules -- topLeft/topRight are a full `dim`
+        // modules apart, so one module step is the span divided by dim, NOT by
+        // dim-1. Dividing by dim-1 stretches every step by dim/(dim-1), which
+        // by row 8 has drifted 8.5/(dim-1) of a module: 0.425 at version 1,
+        // against a half-module of tolerance. It read the right module on clean
+        // renders and had almost nothing left for a photo or a rounded module.
+        // With the correct step the `+ 0.5` offsets below land on module centres.
+        const dim = code.version * 4 + 17, dist = dim;
         const dX_col = (tr.x - tl.x) / dist, dY_col = (tr.y - tl.y) / dist;
         const dX_row = (bl.x - tl.x) / dist, dY_row = (bl.y - tl.y) / dist;
 
@@ -120,18 +130,89 @@ function runDP(text, uT, pT) {
         s = uT ? s.toUpperCase() : s;
     }
 
-    const n = s.length, dp = Array(n+1).fill(Infinity), back = Array(n+1).fill(null); dp[0] = 0;
-    for(let i=0; i<n; i++) for(let j=i+1; j<=n; j++) {
-        const sub = s.substring(i,j);
-        const modes = [{m:'numeric',v:/^[0-9]+$/.test(sub)}, {m:'alphanumeric',v:/^[0-9A-Z $%*+\-./:]+$/.test(sub)}, {m:'byte',v:true}];
-        for(const {m,v} of modes) if(v) {
-            const c = SEG_HEADER_BITS[m] + getBits(sub,m);
-            if(dp[i]+c < dp[j]) { dp[j] = dp[i]+c; back[j] = {f:i,m,d:sub,c}; }
+    const n = s.length;
+
+    // The DP still considers every (start, end) pair, but it used to do so by
+    // cutting a fresh substring for each one and running two regexes and a
+    // TextEncoder over it -- O(n^3) work, on the main thread, on every
+    // keystroke. A 400-character payload took 400ms and an 800-character one
+    // 1.8 SECONDS per edit, which read as the tab hanging. The tables below
+    // answer the same three questions in constant time per pair:
+    //   numRunEnd[i] / alnRunEnd[i]  how far a segment starting at i may run
+    //                                and still be all-numeric / all-alphanumeric
+    //   utf8Prefix[i]                UTF-8 bytes in s[0..i), so a byte segment's
+    //                                length is one subtraction
+    // Same search, same tie-breaks, same answer -- just without the allocation.
+    const numRunEnd = new Int32Array(n + 1);
+    const alnRunEnd = new Int32Array(n + 1);
+    const utf8Prefix = new Int32Array(n + 1);
+    numRunEnd[n] = alnRunEnd[n] = n;
+    for (let i = n - 1; i >= 0; i--) {
+        const ch = s.charCodeAt(i);
+        const isNum = ch >= 48 && ch <= 57;
+        // 0-9 A-Z space $ % * + - . / :  -- the QR alphanumeric set
+        const isAln = isNum || (ch >= 65 && ch <= 90) || ch === 32 || ch === 36 ||
+                      ch === 37 || ch === 42 || ch === 43 || ch === 45 ||
+                      ch === 46 || ch === 47 || ch === 58;
+        numRunEnd[i] = isNum ? numRunEnd[i + 1] : i;
+        alnRunEnd[i] = isAln ? alnRunEnd[i + 1] : i;
+    }
+    for (let i = 0; i < n; i++) {
+        const ch = s.charCodeAt(i);
+        let bytes;
+        if (ch < 0x80) bytes = 1;
+        else if (ch < 0x800) bytes = 2;
+        // A surrogate pair is 4 UTF-8 bytes, counted as 2 against each half so
+        // that any prefix difference still totals correctly.
+        else if (ch >= 0xD800 && ch <= 0xDBFF && i + 1 < n) {
+            const next = s.charCodeAt(i + 1);
+            bytes = (next >= 0xDC00 && next <= 0xDFFF) ? 2 : 3;
+        }
+        else if (ch >= 0xDC00 && ch <= 0xDFFF && i > 0) {
+            const prev = s.charCodeAt(i - 1);
+            bytes = (prev >= 0xD800 && prev <= 0xDBFF) ? 2 : 3;
+        }
+        else bytes = 3;
+        utf8Prefix[i + 1] = utf8Prefix[i] + bytes;
+    }
+
+    const dp = new Float64Array(n + 1).fill(Infinity);
+    const backFrom = new Int32Array(n + 1).fill(-1);
+    const backMode = new Array(n + 1).fill(null);
+    dp[0] = 0;
+
+    for (let i = 0; i < n; i++) {
+        const base = dp[i];
+        if (base === Infinity) continue;
+        const numEnd = numRunEnd[i], alnEnd = alnRunEnd[i], byteBase = utf8Prefix[i];
+        // Modes are tried numeric, then alphanumeric, then byte, and start
+        // positions ascend, so a strict < keeps the original tie-breaking.
+        for (let j = i + 1; j <= n; j++) {
+            const len = j - i;
+            if (j <= numEnd) {
+                const c = base + SEG_HEADER_BITS.numeric + Math.floor(len/3)*10 + NUMERIC_TAIL_BITS[len%3];
+                if (c < dp[j]) { dp[j] = c; backFrom[j] = i; backMode[j] = 'numeric'; }
+            }
+            if (j <= alnEnd) {
+                const c = base + SEG_HEADER_BITS.alphanumeric + Math.floor(len/2)*11 + (len%2===1?6:0);
+                if (c < dp[j]) { dp[j] = c; backFrom[j] = i; backMode[j] = 'alphanumeric'; }
+            }
+            const cb = base + SEG_HEADER_BITS.byte + (utf8Prefix[j] - byteBase)*8;
+            if (cb < dp[j]) { dp[j] = cb; backFrom[j] = i; backMode[j] = 'byte'; }
         }
     }
-    let segs = [], currIdx = n;
-    while(currIdx > 0) { let st = back[currIdx]; segs.unshift({mode:st.m, data:st.d, bits:st.c}); currIdx = st.f; }
-    return { segs, dpBits: dp[n], finalString: s };
+
+    // Segment text is cut once, here, rather than n^2 times above.
+    let segs = [], currIdx = n, dpBits = 0;
+    while (currIdx > 0) {
+        const from = backFrom[currIdx], mode = backMode[currIdx];
+        const data = s.substring(from, currIdx);
+        const bits = SEG_HEADER_BITS[mode] + getBits(data, mode);
+        segs.unshift({ mode, data, bits });
+        dpBits += bits;
+        currIdx = from;
+    }
+    return { segs, dpBits, finalString: s };
 }
 
 function analyzeData() {

--- a/fpqr/js/renderer.js
+++ b/fpqr/js/renderer.js
@@ -225,7 +225,14 @@ function renderCanvas() {
         ctx.fillStyle = heatmap ? '#1a1d27' : bgGrad;
         ctx.fillRect(0, 0, cSz, cSz);
 
-        const aps = AP_LOCATIONS[oV] || [];
+        // Derive the version from the matrix in hand rather than reusing oV.
+        // renderM draws BOTH previews, and a version override can leave the
+        // naive matrix on a different version than the optimised one (override
+        // V3 on a payload whose byte encoding needs V4). Reading oV for both
+        // then drew the naive preview's alignment square at V3's coordinates on
+        // a V4 grid -- [6,22] where the pattern actually sits at [6,26].
+        const matrixV = (matrix.modules.size - 17) / 4;
+        const aps = AP_LOCATIONS[matrixV] || [];
         const sz = cSz * (pct/100), padPx = cSz * (padPct/100), tSz = sz + (padPx * 2), pXy = (cSz - tSz) / 2, lC = cSz / 2;
 
         const isModuleObscured = (r, c) => {
@@ -314,7 +321,12 @@ function renderCanvas() {
         }
 
         const drawStruct = (r, c, x, y, size, type) => {
-            let obscured = isModuleObscured(type === 'finder' ? r+3 : r, type === 'finder' ? c+3 : c);
+            // r,c is the top-left cell of the structure; both branches want its
+            // centre -- 3 in from the corner of a 7x7 finder, 2 for a 5x5
+            // alignment. The alignment case was reading the corner, so the
+            // heatmap flagged the wrong patterns as logo-obscured.
+            const ctrOff = type === 'finder' ? 3 : 2;
+            let obscured = isModuleObscured(r + ctrOff, c + ctrOff);
             if (heatmap && obscured) { ctx.fillStyle = '#ef4444'; ctx.strokeStyle = '#ef4444'; }
             else if (heatmap) { setHeatmapColor(type); }
             else {
@@ -364,7 +376,19 @@ function renderCanvas() {
             }); });
         }
 
-        const batchSolidPath = shape === 'solid' && !isAnimated ? new Path2D() : null;
+        // Batching every solid module into one Path2D and filling it once is a
+        // big win, but it can only be done when every module is the SAME fill at
+        // the SAME size: a Path2D records absolute coordinates, so the per-module
+        // ctx.scale() below never reaches it, and one ctx.fill() can only carry
+        // one colour. Batching unconditionally silently dropped both -- an image
+        // colour map painted every solid module flat black, and a radial or image
+        // density map did nothing at all (identical output, to the pixel).
+        const perModuleColor = colorStyle === 'image' && !!hMapColor;
+        const perModuleSize = densityMapStyle === 'radial' ||
+                              (densityMapStyle === 'image' && !!hMapDensity);
+        const canBatchSolid = shape === 'solid' && !isAnimated && !heatmap &&
+                              !perModuleColor && !perModuleSize;
+        const batchSolidPath = canBatchSolid ? new Path2D() : null;
 
         // CHARACTER MODE
         // Rasterize glyph once via getGlyphSprite(), then stamp with drawImage().
@@ -380,6 +404,20 @@ function renderCanvas() {
                 for (let c = 0; c < gSz; c++) {
                     if (!shouldRenderData(r, c)) continue;
                     const cx = (c+marg)*cell, cy = (r+marg)*cell;
+
+                    // The heatmap is about which modules are which, so it wins
+                    // over the glyph -- otherwise switching to character shape
+                    // left the heatmap showing plain black on dark, with none of
+                    // the finder / alignment / data / obscured colours it exists
+                    // to show.
+                    if (heatmap) {
+                        if (isModuleObscured(r, c))  { ctx.fillStyle = '#ef4444'; }
+                        else if (isFinder(r, c))     setHeatmapColor('finder');
+                        else if (isAlignment(r, c))  setHeatmapColor('alignment');
+                        else                         setHeatmapColor('data');
+                        ctx.fillRect(cx, cy, cell, cell);
+                        continue;
+                    }
 
                     let dX = 0, dY = 0, dS = 1.0;
                     if (isAnimated) {
@@ -567,7 +605,12 @@ function renderCanvas() {
         }
     };
 
-    if (!isAnimated && !getHasAnimatedGif()) {
+    // The naive canvas is a 1024x1024 comparison view behind the "Show naive"
+    // toggle, which is off by default. Drawing it into a hidden container cost
+    // ~18% of every render for something nobody was looking at.
+    const naiveVisible = !!E('show-naive')?.checked &&
+                         !E('naive-container')?.classList.contains('hidden');
+    if (naiveVisible && !isAnimated && !getHasAnimatedGif()) {
         renderM('qr-naive', nData);
     }
     renderM('qr-optimal', oData);
@@ -610,6 +653,12 @@ function animLoop(timestamp) {
     if (!isAnimMeshOn && !getHasAnimatedGif()) {
         lastAnimTime = 0;
         window.animLoopId = null;
+        // One last paint on the way out. The loop stopped mid-displacement, so
+        // without this the preview stayed frozen on whatever frame it happened
+        // to be on -- and an HD export taken afterwards baked that in. This is
+        // the one place every way of stopping goes through (the toggle, a
+        // config import, clearing an animated logo), so it belongs here.
+        renderCanvas();
         return;
     }
     if (!lastAnimTime) lastAnimTime = timestamp;
@@ -621,7 +670,14 @@ function animLoop(timestamp) {
         const speed = parseInt(E('anim-speed')?.value || '30') / 30;
         globalTime += (safeDelta * 0.003) * speed;
     }
-    renderCanvas();
+    // Reschedule even if the render throws. When an exception escaped here the
+    // rAF chain died with window.animLoopId still holding a stale handle, so
+    // startAnimIfNeeded() saw a "running" loop forever and the preview froze
+    // until reload. That is what the callers' `animLoopId = null` resets were
+    // working around -- and those resets are what started a second loop
+    // alongside a live one.
+    try { renderCanvas(); }
+    catch (e) { console.error('Render failed inside the animation loop:', e); }
     window.animLoopId = requestAnimationFrame(animLoop);
 }
 


### PR DESCRIPTION
Everything here looked like it worked.

decodeGif() read tracks.selectedTrack on the line after constructing the
ImageDecoder, where it is still null because the track list fills in from
the stream. It threw every single time, the catch swallowed it, and every
animated logo, colour map and density map loaded as one frozen frame with
no error shown. Awaiting tracks.ready and completed gets the frames; the
uploaders now say so when a GIF still cannot be read.

The Path2D that batches solid modules into one fill can only carry one
colour and cannot see the per-module scale, so batching it unconditionally
threw both away: an image colour map painted every solid module flat black,
and a density map changed nothing at all, to the pixel. Batch only when
every module really is the same fill at the same size.

The animation toggle was starting two render loops. It matched the generic
.render-trigger input handler as well as its own change handler, a click
fires both, and both cleared the loop guard before restarting -- so every
frame was rendered twice for the rest of the session. There is one handler
now, and animLoop reschedules even if the render throws so a thrown frame
can no longer strand the guard, which is what the clearing was working
around. Switching the mesh off also repaints once on the way out; the
preview used to stay frozen mid-displacement, and an HD export taken
afterwards baked that in.

The segmentation DP cut a fresh substring and ran two regexes and a
TextEncoder over it for every start/end pair. An 800-character payload took
1.8 seconds per keystroke and read as the tab hanging. Precomputed run
lengths and a UTF-8 prefix sum answer the same questions in constant time:
identical segments and bit counts on 5800 random payloads, and a
full-capacity 2900-character payload now takes 10ms instead of a minute.

Smaller ones: the naive preview drew its alignment square using the
optimised code's version, so a version override put it at the wrong
coordinates; the heatmap was invisible in character mode and flagged the
wrong alignment patterns as logo-obscured; the hidden naive canvas was
rendered at 1024x1024 anyway, for 18% of every frame; the GIF export took
its frame count straight from the source GIF, asking for 2GB of held frames
on a 20-second loop, and leaked its blob URL, and a second export could be
started on top of the first; and format-info extraction stepped by dim-1
where jsQR's corners are a full dim apart, spending all but 7% of a module
of its tolerance before it read a single pixel.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G7vVAfRMBnaRXBXjzwfGN1