### PR TITLE
Spatial video in, parallax preview out, and a still held long enough to upload

### DIFF
--- a/spatialize.html
+++ b/spatialize.html
@@ -108,6 +108,25 @@
   the browser only offers WebM the tool says so rather than pretending.
   Dimensions are forced even — H.264 refuses odd ones.
 
+  RECOVERING iOS'S OWN DEPTH FROM SCREENSHOTS
+  ───────────────────────────────────────────
+  The Spatial Scene depth never leaves the phone as a file — but the
+  SCREEN shows it. Tilt the phone to one extreme and screenshot, tilt to
+  the other and screenshot again, and those two frames are a synthetic
+  stereo pair rendered from Apple's own depth map. Panel 2's pair mode
+  inverts that: a coarse-to-fine global alignment absorbs any framing
+  drift between the shots, then the same SAD matcher (with ±1 px of
+  vertical slack for imperfect alignment) turns the residual per-pixel
+  parallax back into a depth map. A screen recording while tilting works
+  too — load it as a video and tag two frames as A and B.
+
+  Sober expectations: what comes back is a reconstruction of the depth
+  iOS *rendered*, complete with its rubber-sheet warping, relative not
+  metric, and mirrored if the tilt went the other way (that's what the
+  invert box is for). Crop both screenshots identically to just the
+  photo first; UI chrome matches itself at zero parallax and wastes
+  normalization range.
+
   Everything runs locally; nothing is uploaded anywhere.
 -->
 <style>
@@ -131,7 +150,9 @@
       <div class="file-name" id="fn-in" hidden></div>
       <div class="row"><label for="dt-in">Taken at</label><input type="datetime-local" id="dt-in" step="1"></div>
       <button class="process-btn" id="btn-build" disabled onclick="buildCameraJpeg()">Build camera-clad JPEG</button>
-      <button class="process-btn" id="btn-dl-jpeg" hidden onclick="dlBlob(outJpeg.name, outJpeg.blob)">Download JPEG</button>
+      <button class="process-btn" id="btn-share-jpeg" hidden onclick="shareOut()">Send to Photos (share sheet)</button>
+      <button class="ghost-btn" id="btn-dl-jpeg" hidden onclick="dlBlob(outJpeg.name, outJpeg.blob)">Download as a file instead</button>
+      <div class="preview-wrap" id="out-wrap" hidden><img id="out-preview" alt="camera-clad JPEG" style="max-width:100%;display:block;border-radius:.25rem"></div>
       <div class="ok-msg" id="ok-in" hidden></div>
       <div class="error-msg" id="err-in" hidden></div>
     </div>
@@ -155,8 +176,21 @@
           <label style="min-width:auto"><input type="checkbox" id="swap-eyes"> swap eyes</label>
         </div>
         <button class="process-btn" id="btn-stereo" onclick="computeStereoDepth()">Compute depth from this frame</button>
+        <div class="row" style="gap:.5rem">
+          <button class="ghost-btn" style="flex:1;margin:0" onclick="tagFrame('a')">Tag frame → A</button>
+          <button class="ghost-btn" style="flex:1;margin:0" onclick="tagFrame('b')">Tag frame → B</button>
+        </div>
         <div class="ok-msg" id="stereo-status" hidden></div>
       </div>
+      <div class="card-desc" style="margin-top:.9rem;margin-bottom:.5rem">…or a stereo pair: two screenshots of a Spatial Scene, tilted to opposite extremes (crop both to just the photo)</div>
+      <div class="row" style="gap:.6rem;align-items:stretch">
+        <div class="drop-zone" id="dz-pa" style="flex:1;padding:1rem .5rem;margin:0" onclick="document.getElementById('fi-pa').click()"><p><strong>A</strong></p><p id="pa-label">tilted one way</p></div>
+        <div class="drop-zone" id="dz-pb" style="flex:1;padding:1rem .5rem;margin:0" onclick="document.getElementById('fi-pb').click()"><p><strong>B</strong></p><p id="pb-label">tilted the other</p></div>
+      </div>
+      <input type="file" id="fi-pa" accept="image/*" onchange="loadPair('a',this.files[0])">
+      <input type="file" id="fi-pb" accept="image/*" onchange="loadPair('b',this.files[0])">
+      <button class="process-btn" id="btn-pair" disabled onclick="computePairDepth()">Compute depth from the pair</button>
+      <div class="ok-msg" id="pair-status" hidden></div>
       <div class="preview-wrap" id="preview-wrap" hidden><canvas id="preview"></canvas></div>
       <div class="row" id="interp-row" hidden>
         <label for="interp">Values are</label>
@@ -244,6 +278,7 @@
       <strong>Toggle still not showing?</strong> The gate is not only metadata. Known additional requirements, all reported in the wild: the phone must be on <em>Wi-Fi</em> (mobile data silently fails), <em>Reduce Motion</em> must be off (Settings → Accessibility → Motion), the <em>full-resolution original</em> must be on the device (with iCloud-optimized storage, open the photo and start-then-cancel an edit to force the download), and it takes an iPhone 12 or newer on iOS 26. Photos may also need a little time after import before the option appears. Work through that list before blaming the EXIF.<br><br>
       <strong>Getting depth out:</strong> the Spatial Scene depth map itself never leaves the phone — Photos renders it live and exports no file containing it. What <em>is</em> extractable, and what panel 2 reads: Portrait-mode shots (HEIC aux disparity image, or the extra JPEGs appended to a shared Portrait JPEG), HDR gain maps, and segmentation mattes. Export the <em>unmodified original</em> from Photos, or AirDrop to a Mac — “most compatible” conversions usually strip the aux images.<br><br>
       <strong>Output format:</strong> 16-bit grayscale PNG, values scaled ×257 from the 8-bit source, plus a JSON sidecar naming the source urn and whether bright means near (disparity) or far (depth). That pair drops straight into MiDaS-style depth pipelines.<br><br>
+      <strong>Recovering iOS's own depth — the screenshot trick:</strong> the Spatial Scene depth never leaves the phone as a file, but the screen renders it. Turn the effect on, tilt the phone to one extreme and screenshot, tilt to the other extreme and screenshot again: those are two views rendered from Apple's own depth map, and the pair mode above inverts the parallax back into that depth. Crop both screenshots identically to just the photo (UI chrome sits at zero parallax and wastes the range), tilt <em>horizontally</em>, and if the result looks inside-out the tilt went the other way — tick invert. A screen recording while tilting works too: load it as a video, scrub, and tag two frames as A and B. What you get is a reconstruction of the depth iOS rendered — relative, not metric, and carrying the renderer's own edge-stretching — but it needs no file-format tricks at all.<br><br>
       <strong>Spatial / Facebook & Meta video:</strong> Meta's side takes stereo video as Apple MV-HEVC (uploaded through the Meta Quest app; a Facebook feed post just shows it flat) or as plain full side-by-side video. Drop a .MOV/.MP4 above and the tool reads the stereo boxes — Apple's <code>vexu</code> (eyes, baseline, disparity adjustment) and the <code>st3d</code> SBS/TB tag — even when the browser can't play the codec. MV-HEVC's second eye is beyond every browser decoder, so flatten to SBS first (<code>ffmpeg</code> 7.1+ decodes MV-HEVC, or Spatialify on iOS) and feed the SBS back in: then you can grab a frame, split the eyes, and compute a real disparity map by block matching, exported in the same 16-bit PNG + JSON format. Facebook's own “3D photo” upload path (2D + depth pair) is long past its heyday — Stories dropped it and it is not something to build on now — so panel 3 goes the other way and hands Meta what it reliably eats: video.<br><br>
       <strong>Panel 3 — preview, and the hold:</strong> load a picture (plus a depth map, if you have one) to see the parallax rendered live, then record it. <em>Flat hold</em> needs no depth at all: it is your still, held for N seconds, as an ordinary video — the thing that uploads anywhere, and what Quest's own photo-to-3D conversion can then chew on. <em>Wiggle</em> oscillates the camera, which is what actually reads as three-dimensional to a phone or desktop feed, since a flat viewer never sees a second eye. <em>Side-by-side</em> writes both eyes into one frame for Quest and any SBS player. MP4/H.264 is requested first because Meta ingests it most happily; if your browser only offers WebM the tool tells you, and <code>ffmpeg -i in.webm -c:v libx264 -pix_fmt yuv420p out.mp4</code> finishes the job. No depth map to hand? Pull one from a Portrait shot above, from a stereo video above, or from any monocular depth model — the 16-bit PNG this tool exports is the same format they emit.<br><br>
       HEIC decoding uses WebCodecs HEVC — works in Safari and in Chrome on hardware with an HEVC decoder. Where it can’t decode, the tool still lists the file’s contents and hands you the raw HEVC payload for <code>heif-convert --with-aux</code> or <code>ffmpeg</code>. Everything runs locally; nothing is uploaded.
@@ -418,6 +453,12 @@ function buildExifApp1(width, height, when){
   return seg;
 }
 
+async function shareOut(){
+  if(!outJpeg) return;
+  try{ await navigator.share({files:[outJpeg.file]}); }
+  catch(e){ /* user dismissed the sheet — nothing to report */ }
+}
+
 async function buildCameraJpeg(){
   setMsg('err-in',''); setMsg('ok-in','');
   try{
@@ -436,9 +477,17 @@ async function buildCameraJpeg(){
     // stays behind it, which real-world files do all the time.
     const out=concatBytes([jpeg.subarray(0,2),app1,jpeg.subarray(2)]);
     outJpeg={name:baseName(inFile.name)+'-camera.jpg', blob:new Blob([out],{type:'image/jpeg'})};
+    outJpeg.file=new File([outJpeg.blob],outJpeg.name,{type:'image/jpeg'});
     show('btn-dl-jpeg',true);
+    // the share sheet is the path that lands in Photos as a photo rather
+    // than in Files as a download — offer it wherever the browser can
+    show('btn-share-jpeg', !!(navigator.canShare&&navigator.canShare({files:[outJpeg.file]})));
+    const prev=$('out-preview');
+    if(prev.src) URL.revokeObjectURL(prev.src);
+    prev.src=URL.createObjectURL(outJpeg.blob);
+    show('out-wrap',true);
     syncHandoffButtons();
-    setMsg('ok-in',`Wrote ${bmp.width}×${bmp.height} JPEG with Apple/iPhone 15 Pro EXIF, DateTimeOriginal ${exifDateString(when)}. AirDrop or save it into Photos, then look for the spatial toggle.`);
+    setMsg('ok-in',`Wrote ${bmp.width}×${bmp.height} JPEG with Apple/iPhone 15 Pro EXIF, DateTimeOriginal ${exifDateString(when)}. On an iPhone use the share sheet (Save Image goes straight into the library) or long-press the preview → Add to Photos; from a computer, AirDrop the file. Then look for the spatial toggle.`);
   }catch(e){
     setMsg('err-in',e.message);
   }
@@ -1452,6 +1501,136 @@ async function recordHold(){
   syncPreview();
 }
 
+/* ── stereo pair mode: two screenshots (or two tagged video frames) ──
+   The pair differs from an SBS frame in one crucial way: the two shots
+   were framed by a human, so before any per-pixel matching a GLOBAL
+   translation between them has to be found and subtracted — otherwise
+   the matcher spends its whole search range on the framing drift and
+   the depth signal drowns. Coarse (quarter-res, wide window) then fine
+   (full working res, ±3) alignment handles that; the per-pixel pass
+   then searches ±10% of width horizontally with ±1 px of vertical
+   slack, since screenshot alignment is never perfectly row-exact.
+   The disparity that remains after the global shift IS the depth iOS
+   rendered — up to sign, which depends on which way the phone tilted;
+   the invert box settles it. */
+
+const pair={a:null,b:null};
+
+async function loadPair(slot,f){
+  if(!f) return;
+  try{
+    const bmp=await createImageBitmap(f);
+    pair[slot]={bitmap:bmp,label:f.name};
+    $(slot==='a'?'pa-label':'pb-label').textContent=`${f.name} ${bmp.width}×${bmp.height}`;
+    syncPairButton();
+  }catch(e){ setMsg('err-x','Could not decode '+f.name+': '+e.message); }
+}
+
+function tagFrame(slot){
+  if(!vidEl||!vidEl.videoWidth) return;
+  const c=document.createElement('canvas');
+  c.width=vidEl.videoWidth; c.height=vidEl.videoHeight;
+  c.getContext('2d').drawImage(vidEl,0,0);
+  const label=`frame @ ${vidEl.currentTime.toFixed(2)}s`;
+  createImageBitmap(c).then(bmp=>{
+    pair[slot]={bitmap:bmp,label};
+    $(slot==='a'?'pa-label':'pb-label').textContent=label;
+    syncPairButton();
+  });
+}
+
+function syncPairButton(){
+  $('btn-pair').disabled=!(pair.a&&pair.b);
+}
+
+function grayFromBitmap(bmp,w,h){
+  const c=document.createElement('canvas'); c.width=w; c.height=h;
+  const ctx=c.getContext('2d',{willReadFrequently:true});
+  ctx.drawImage(bmp,0,0,w,h);
+  const d=ctx.getImageData(0,0,w,h).data, g=new Uint8Array(w*h);
+  for(let i=0;i<g.length;i++) g[i]=(d[i*4]*77+d[i*4+1]*150+d[i*4+2]*29)>>8;
+  return g;
+}
+function sadShift(A,B,w,h,cx,cy,rx,ry,step){
+  // best (dx,dy) minimizing mean |A(x,y)-B(x+dx,y+dy)| over the overlap
+  let best=Infinity,bx=0,by=0;
+  for(let dy=cy-ry;dy<=cy+ry;dy++) for(let dx=cx-rx;dx<=cx+rx;dx++){
+    let s=0,n=0;
+    for(let y=Math.max(8,-dy);y<h-Math.max(8,dy);y+=step)
+      for(let x=Math.max(8,-dx);x<w-Math.max(8,dx);x+=step){ s+=Math.abs(A[y*w+x]-B[(y+dy)*w+x+dx]); n++; }
+    if(n>200){ const m=s/n; if(m<best){best=m;bx=dx;by=dy;} }
+  }
+  return {dx:bx,dy:by,err:best};
+}
+
+async function computePairDepth(){
+  if(!(pair.a&&pair.b)) return;
+  setMsg('err-x','');
+  const A=pair.a.bitmap,B=pair.b.bitmap;
+  if(Math.abs(A.width/A.height-B.width/B.height)>0.03)
+    return setMsg('err-x',`The two images have different shapes (${A.width}×${A.height} vs ${B.width}×${B.height}). Crop them identically first.`);
+  const w=Math.min(420,A.width), h=Math.round(w*A.height/A.width);
+  const ga=grayFromBitmap(A,w,h), gb=grayFromBitmap(B,w,h);
+  const status=t=>{ const el=$('pair-status'); el.textContent=t; el.hidden=false; };
+  const tick=()=>new Promise(r=>setTimeout(r));
+  status('aligning…'); await tick();
+
+  // Align on BLURRED copies at full resolution. A decimating coarse pass
+  // was tried first and failed on fine texture: point-sampling every 4th
+  // pixel decorrelates any shift that isn't a multiple of 4, and the
+  // aligner locked onto the nearest multiple instead of the truth. Blur
+  // gives the texture a correlation length the sparse SAD can grip.
+  const ba=boxBlur(ga,w,h,2), bb=boxBlur(gb,w,h,2);
+  const rough=sadShift(ba,bb,w,h,0,0,Math.round(w*0.25),Math.round(h*0.12),3);
+  const fine=sadShift(ba,bb,w,h,rough.dx,rough.dy,2,2,1);
+  const gx=fine.dx, gy=fine.dy;
+
+  const range=Math.max(8,Math.round(w*0.10)), B2=3;
+  const disp=new Float32Array(w*h).fill(-range-1);
+  for(let y=B2;y<h-B2;y++){
+    for(let x=B2;x<w-B2;x++){
+      let best=Infinity,bd=0;
+      for(let d=-range;d<=range;d++) for(let j=-1;j<=1;j++){
+        const xb=x+gx+d, yb=y+gy+j;
+        if(xb-B2<0||xb+B2>=w||yb-B2<0||yb+B2>=h) continue;
+        let sad=0;
+        for(let dy=-B2;dy<=B2&&sad<best;dy++){
+          const ao=(y+dy)*w+x, bo=(yb+dy)*w+xb;
+          for(let dx=-B2;dx<=B2;dx++) sad+=Math.abs(ga[ao+dx]-gb[bo+dx]);
+        }
+        if(sad<best){ best=sad; bd=d; }
+      }
+      disp[y*w+x]=bd;
+    }
+    if((y&15)===0){ status(`matching… ${Math.round(100*y/h)}%`); await tick(); }
+  }
+  const valid=[];
+  for(let i=0;i<disp.length;i++) if(disp[i]>=-range) valid.push(disp[i]);
+  valid.sort((a,b)=>a-b);
+  const p2=valid[Math.floor(valid.length*0.02)]||-range;
+  const p98=valid[Math.floor(valid.length*0.98)]||range;
+  const span=Math.max(1e-6,p98-p2);
+  const gray=new Uint8Array(w*h);
+  for(let i=0;i<disp.length;i++){
+    const v=disp[i]<-range?p2:disp[i];
+    gray[i]=Math.max(0,Math.min(255,Math.round((v-p2)/span*255)));
+  }
+  status(`done — global shift (${gx},${gy}) px, residual parallax ${p2.toFixed(1)}…${p98.toFixed(1)} px`);
+  grayResult={gray,w,h};
+  if(!xFile) xFile={name:baseName(pair.a.label)||'pair'};
+  selected={kind:'screen-pair',label:'depth recovered from a screenshot pair',
+    urn:'(parallax inversion of two rendered views)',
+    extra:{a:pair.a.label,b:pair.b.label,global_shift_px:[gx,gy],
+      search_range_px:range,vertical_slack_px:1,block:'7x7',working_width:w,
+      normalization:`2-98 percentile, ${p2.toFixed(1)}..${p98.toFixed(1)} px`,
+      sign_note:'depends on tilt direction — invert if it looks inside-out'}};
+  $('interp').value='disparity'; $('invert').checked=false;
+  renderSelected();
+  ['preview-wrap','interp-row','btn-png','btn-json'].forEach(id=>show(id,true));
+  show('btn-raw',false);
+  syncHandoffButtons();
+}
+
 /* ── hand-written 16-bit grayscale PNG ── */
 
 const CRC_TABLE=(()=>{
@@ -1527,7 +1706,8 @@ function exportJson(){
     source_file:xFile.name,
     source:{ 'jpeg-sub':'JPEG appended sub-image',
              'heic-aux':'HEIC auxiliary item',
-             'stereo-frame':'disparity computed from a stereo video frame' }[selected.kind],
+             'stereo-frame':'disparity computed from a stereo video frame',
+             'screen-pair':'depth recovered from two rendered views (screenshot parallax)' }[selected.kind],
     aux_type_urn:selected.urn||null,
     width:grayResult.w, height:grayResult.h,
     interpretation:interp,

--- a/spatialize.html
+++ b/spatialize.html
@@ -60,6 +60,27 @@
   zlib stream, CRC32 and Adler32 included — bigger than a real compressor's
   output but dependency-free and bit-exact.
 
+  SPATIAL / STEREO VIDEO (the Facebook & Meta Quest side)
+  ────────────────────────────────────────────────────────
+  Meta's ecosystem takes stereo video two ways: Apple's MV-HEVC "spatial
+  video" (both eyes as HEVC layers in one track, uploaded via the Quest
+  app) and plain full side-by-side video. Panel 2 accepts .MOV/.MP4 too:
+
+    • The QuickTime/MP4 boxes are parsed for the stereo signals — Apple's
+      vexu box (stri eye flags, hero eye, cams/blin baseline in µm,
+      cmfy/dadj disparity adjustment) and the spherical-video st3d box —
+      so you can see at a glance what a file claims to be.
+    • MV-HEVC's second eye rides in NAL layers no browser decoder will
+      touch; hardware decoders play the base (left) eye and drop the rest.
+      Flatten to SBS first (ffmpeg 7.1+ decodes MV-HEVC, or an app like
+      Spatialify) and bring the SBS back here.
+    • For any stereo video the browser can play, a frame can be grabbed,
+      split into eyes, and run through a small SAD block matcher (7×7
+      blocks, ±8% search, percentile-normalized) to compute an actual
+      disparity map — exported through the same 16-bit PNG + JSON path.
+      Research-grade, not Apple-grade: it's honest window matching, no
+      smoothing, no ML. Near objects come out bright.
+
   Everything runs locally; nothing is uploaded anywhere.
 -->
 <style>
@@ -90,14 +111,25 @@
 
     <div class="card">
       <div class="card-title">2 · Pull the depth back out</div>
-      <p class="card-desc">Feed it a Portrait HEIC, a Portrait shared as JPEG, or any HEIC with auxiliary images. Exports 16-bit grayscale PNG + JSON sidecar.</p>
+      <p class="card-desc">Feed it a Portrait HEIC, a Portrait shared as JPEG, any HEIC with auxiliary images — or a spatial / side-by-side video. Exports 16-bit grayscale PNG + JSON sidecar.</p>
       <div class="drop-zone" id="dz-x" onclick="document.getElementById('fi-x').click()">
-        <p><strong>Click or drop a HEIC or JPEG</strong></p>
+        <p><strong>Click or drop a HEIC, JPEG, MOV or MP4</strong></p>
         <p>exported from Photos as “unmodified original”</p>
       </div>
-      <input type="file" id="fi-x" accept=".heic,.heif,.jpg,.jpeg,image/heic,image/heif,image/jpeg" onchange="pickX(this.files[0])">
+      <input type="file" id="fi-x" accept=".heic,.heif,.jpg,.jpeg,.mov,.mp4,image/heic,image/heif,image/jpeg,video/quicktime,video/mp4" onchange="pickX(this.files[0])">
       <div class="file-name" id="fn-x" hidden></div>
       <div class="item-list" id="item-list"></div>
+      <div id="video-ui" hidden>
+        <div class="preview-wrap"><canvas id="vid-frame"></canvas></div>
+        <div class="row"><label for="vid-time">Frame at</label><input type="range" id="vid-time" min="0" max="0" value="0" step="0.05" style="flex:1" oninput="seekVideo(this.value)"><span id="vid-time-label">0.0s</span></div>
+        <div class="row">
+          <label for="layout">Stereo layout</label>
+          <select id="layout"><option value="sbs">side-by-side</option><option value="tb">top-bottom</option></select>
+          <label style="min-width:auto"><input type="checkbox" id="swap-eyes"> swap eyes</label>
+        </div>
+        <button class="process-btn" id="btn-stereo" onclick="computeStereoDepth()">Compute depth from this frame</button>
+        <div class="ok-msg" id="stereo-status" hidden></div>
+      </div>
       <div class="preview-wrap" id="preview-wrap" hidden><canvas id="preview"></canvas></div>
       <div class="row" id="interp-row" hidden>
         <label for="interp">Values are</label>
@@ -126,8 +158,10 @@
         <li>Get it into the iPhone photo library <em>as a photo</em>: AirDrop it, or save to Files and share → Save Image. It should land in the main library, not in Screenshots.</li>
         <li>Open it in Photos on iOS 26+ and tap the spatial (hexagon) button top-right. The depth is inferred on-device, on the spot.</li>
       </ol>
+      <strong>Toggle still not showing?</strong> The gate is not only metadata. Known additional requirements, all reported in the wild: the phone must be on <em>Wi-Fi</em> (mobile data silently fails), <em>Reduce Motion</em> must be off (Settings → Accessibility → Motion), the <em>full-resolution original</em> must be on the device (with iCloud-optimized storage, open the photo and start-then-cancel an edit to force the download), and it takes an iPhone 12 or newer on iOS 26. Photos may also need a little time after import before the option appears. Work through that list before blaming the EXIF.<br><br>
       <strong>Getting depth out:</strong> the Spatial Scene depth map itself never leaves the phone — Photos renders it live and exports no file containing it. What <em>is</em> extractable, and what panel 2 reads: Portrait-mode shots (HEIC aux disparity image, or the extra JPEGs appended to a shared Portrait JPEG), HDR gain maps, and segmentation mattes. Export the <em>unmodified original</em> from Photos, or AirDrop to a Mac — “most compatible” conversions usually strip the aux images.<br><br>
       <strong>Output format:</strong> 16-bit grayscale PNG, values scaled ×257 from the 8-bit source, plus a JSON sidecar naming the source urn and whether bright means near (disparity) or far (depth). That pair drops straight into MiDaS-style depth pipelines.<br><br>
+      <strong>Spatial / Facebook & Meta video:</strong> Meta's side takes stereo video as Apple MV-HEVC (uploaded through the Meta Quest app; a Facebook feed post just shows it flat) or as plain full side-by-side video. Drop a .MOV/.MP4 above and the tool reads the stereo boxes — Apple's <code>vexu</code> (eyes, baseline, disparity adjustment) and the <code>st3d</code> SBS/TB tag — even when the browser can't play the codec. MV-HEVC's second eye is beyond every browser decoder, so flatten to SBS first (<code>ffmpeg</code> 7.1+ decodes MV-HEVC, or Spatialify on iOS) and feed the SBS back in: then you can grab a frame, split the eyes, and compute a real disparity map by block matching, exported in the same 16-bit PNG + JSON format. Facebook's old “3D photo” post type (2D + depth pair) was retired, so there is nothing left to inject depth into on the feed side.<br><br>
       HEIC decoding uses WebCodecs HEVC — works in Safari and in Chrome on hardware with an HEVC decoder. Where it can’t decode, the tool still lists the file’s contents and hands you the raw HEVC payload for <code>heif-convert --with-aux</code> or <code>ffmpeg</code>. Everything runs locally; nothing is uploaded.
     </div>
   </div>
@@ -334,14 +368,20 @@ function pickX(f){
   xFile=f; xPayloads=[]; selected=null; grayResult=null;
   $('fn-x').textContent=f.name; show('fn-x',true);
   $('item-list').innerHTML='';
-  ['preview-wrap','interp-row','btn-png','btn-json','btn-raw'].forEach(id=>show(id,false));
+  ['preview-wrap','interp-row','btn-png','btn-json','btn-raw','video-ui','stereo-status'].forEach(id=>show(id,false));
+  if(vidEl){ vidEl.remove(); vidEl=null; }
   setMsg('err-x','');
   f.arrayBuffer().then(buf=>{
     const bytes=new Uint8Array(buf);
     try{
-      if(bytes[0]===0xFF&&bytes[1]===0xD8) scanJpeg(bytes);
-      else if(String.fromCharCode(...bytes.subarray(4,8))==='ftyp') scanHeic(bytes);
-      else throw new Error('Not a JPEG or HEIC/HEIF file.');
+      if(bytes[0]===0xFF&&bytes[1]===0xD8) return scanJpeg(bytes);
+      if(String.fromCharCode(...bytes.subarray(4,8))==='ftyp'){
+        // ftyp major brand tells HEIF stills from movie files
+        const brand=String.fromCharCode(...bytes.subarray(8,12));
+        if(/^(heic|heix|heim|heis|hevc|mif1|msf1|avif)$/.test(brand)) return scanHeic(bytes);
+        return scanVideo(bytes,f);
+      }
+      throw new Error('Not a JPEG, HEIC/HEIF, or MP4/MOV file.');
     }catch(e){ setMsg('err-x',e.message); }
   });
 }
@@ -716,6 +756,220 @@ function renderSelected(){
   ctx.putImageData(img,0,0);
 }
 
+/* ───────────────── spatial / stereo video ─────────────────
+   Two independent things happen for a .MOV/.MP4: the box structure is
+   parsed for stereo signals (works even when the browser can't play the
+   codec at all), and — if the browser CAN play it — a frame can be
+   grabbed, split into eyes, and block-matched into a disparity map. */
+
+let vidEl=null, videoInfo=null;
+
+function scanVideo(bytes,file){
+  const dv=new DataView(bytes.buffer,bytes.byteOffset,bytes.byteLength);
+  const info={codecs:[],vexu:null,st3d:null,sv3d:false,mvhc:false,duration:0};
+
+  const CONTAINERS=new Set(['moov','trak','mdia','minf','stbl','edts','udta','mvex']);
+  function fourcc(p){ return String.fromCharCode(bytes[p],bytes[p+1],bytes[p+2],bytes[p+3]); }
+  function walk(start,end){
+    let p=start;
+    while(p+8<=end){
+      let size=dv.getUint32(p), hdr=8;
+      const type=fourcc(p+4);
+      if(size===1){ size=Number(dv.getBigUint64(p+8)); hdr=16; }
+      else if(size===0) size=end-p;
+      if(size<hdr||p+size>end) break;
+      const body=p+hdr, bodyEnd=p+size;
+      if(CONTAINERS.has(type)) walk(body,bodyEnd);
+      else if(type==='mvhd'){
+        const v=bytes[body];
+        const ts=v===1?dv.getUint32(body+20):dv.getUint32(body+12);
+        const dur=v===1?Number(dv.getBigUint64(body+24)):dv.getUint32(body+16);
+        if(ts) info.duration=dur/ts;
+      }
+      else if(type==='stsd'){
+        const n=dv.getUint32(body+4);
+        let q=body+8;
+        for(let i=0;i<n&&q+16<=bodyEnd;i++){
+          const es=dv.getUint32(q), et=fourcc(q+4);
+          if(/^(hvc1|hev1|avc1|avc3|dvh1|dvhe|ap4h|mp4v|vp09|av01)$/.test(et)){
+            const entry={type:et,w:dv.getUint16(q+8+24),h:dv.getUint16(q+8+26),children:[]};
+            // visual sample entry: 78 bytes of fields after the box header,
+            // then child boxes (hvcC, vexu, st3d, colr, …)
+            walkEntry(q+86,q+es,entry);
+            info.codecs.push(entry);
+          }
+          q+=es||8;
+        }
+      }
+      p+=size;
+    }
+  }
+  function walkEntry(start,end,entry){
+    let p=start;
+    while(p+8<=end){
+      const size=dv.getUint32(p), type=fourcc(p+4);
+      if(size<8||p+size>end) break;
+      entry.children.push(type);
+      if(type==='vexu') info.vexu=parseVexu(p+8,p+size);
+      else if(type==='st3d') info.st3d=bytes[p+8+4]; // fullbox hdr, then stereo_mode
+      else if(type==='sv3d') info.sv3d=true;
+      else if(type==='lhvC') info.mvhc=true; // layered-HEVC config = MV-HEVC second eye
+      p+=size;
+    }
+  }
+  function parseVexu(start,end){
+    const v={boxes:[]};
+    let p=start;
+    while(p+8<=end){
+      const size=dv.getUint32(p), type=fourcc(p+4);
+      if(size<8||p+size>end) break;
+      v.boxes.push(type);
+      if(type==='stri') v.stri=bytes[p+8+4];           // eye-presence flags
+      else if(type==='hero') v.hero=bytes[p+8+4];
+      else if(type==='cams'||type==='cmfy'){           // containers: blin / dadj leaves
+        let q=p+8;
+        while(q+8<=p+size){
+          const s=dv.getUint32(q), t=fourcc(q+4);
+          if(s<8||q+s>p+size) break;
+          if(t==='blin') v.baseline_um=dv.getUint32(q+8+4);
+          if(t==='dadj') v.dadj=dv.getInt32(q+8+4)/10000;
+          q+=s;
+        }
+      }
+      p+=size;
+    }
+    return v;
+  }
+  walk(0,bytes.length);
+  videoInfo=info;
+
+  const list=$('item-list');
+  const add=(strong,small)=>{
+    const d=document.createElement('div');
+    d.className='item-btn'; d.style.cursor='default';
+    d.innerHTML=`<strong>${strong}</strong>${small?`<small>${small}</small>`:''}`;
+    list.appendChild(d);
+  };
+  for(const c of info.codecs)
+    add(`video track: ${c.type} ${c.w}×${c.h}`,`sample-entry boxes: ${c.children.join(', ')||'none'}`);
+  if(info.vexu){
+    const eyes=info.vexu.stri==null?'?':((info.vexu.stri&1?'left':'')+(info.vexu.stri&2?(info.vexu.stri&1?'+right':'right'):''))||'none';
+    add('Apple spatial video (vexu box)',
+      `eyes: ${eyes}${info.vexu.baseline_um?` · baseline ${(info.vexu.baseline_um/1000).toFixed(1)}mm`:''}${info.vexu.dadj!=null?` · disparity adj ${info.vexu.dadj}`:''} · sub-boxes: ${info.vexu.boxes.join(', ')}`);
+  }
+  if(info.mvhc||info.vexu)
+    add('MV-HEVC: second eye not browser-decodable',
+      'browsers decode only the base (left) eye — flatten to side-by-side with ffmpeg 7.1+ or Spatialify, then feed the SBS back here for depth');
+  if(info.st3d!=null)
+    add(`st3d stereo mode: ${['mono','top-bottom','side-by-side'][info.st3d]||info.st3d}`,'spherical-video v2 tag');
+  if(!info.codecs.length) add('no video track found','moov box missing or unrecognized');
+  else if(!info.vexu&&info.st3d==null)
+    add('no stereo metadata','if the picture is visibly doubled it is untagged SBS/TB — pick the layout below');
+
+  // playback side: only works for codecs this browser has
+  vidEl=document.createElement('video');
+  vidEl.muted=true; vidEl.playsInline=true; vidEl.preload='auto';
+  vidEl.src=URL.createObjectURL(file);
+  vidEl.addEventListener('loadeddata',()=>{
+    show('video-ui',true);
+    $('vid-time').max=vidEl.duration.toFixed(2);
+    if(info.st3d===1) $('layout').value='tb';
+    else $('layout').value='sbs';
+    seekVideo(0);
+  });
+  vidEl.addEventListener('error',()=>{
+    setMsg('err-x','This browser cannot decode the video codec ('+(info.codecs[0]?info.codecs[0].type:'?')+'), so no frames can be grabbed — metadata above is all that is extractable here. Safari decodes HEVC; Chrome usually only with hardware support.');
+  });
+}
+
+function drawVideoFrame(){
+  const c=$('vid-frame'), s=Math.min(1,420/vidEl.videoWidth);
+  c.width=Math.round(vidEl.videoWidth*s); c.height=Math.round(vidEl.videoHeight*s);
+  c.getContext('2d').drawImage(vidEl,0,0,c.width,c.height);
+}
+function seekVideo(t){
+  if(!vidEl) return;
+  $('vid-time-label').textContent=(+t).toFixed(1)+'s';
+  vidEl.addEventListener('seeked',drawVideoFrame,{once:true});
+  vidEl.currentTime=+t;
+  // seeking to the time we're already at fires no 'seeked'; draw anyway
+  drawVideoFrame();
+}
+
+/* SAD block matcher. Deliberately simple: 7×7 windows, row-wise search of
+   ±8% of eye width, winner-take-all, then 2–98 percentile normalization.
+   No smoothing, no sub-pixel, no ML — it's a truth-teller, not a beautifier.
+   Sign convention: a near object sits further LEFT in the right eye, so we
+   search R at x−d and positive d (near) comes out bright = disparity. */
+
+async function computeStereoDepth(){
+  if(!vidEl||!vidEl.videoWidth) return;
+  const layout=$('layout').value, swap=$('swap-eyes').checked;
+  const W=vidEl.videoWidth, H=vidEl.videoHeight;
+  const full=document.createElement('canvas');
+  full.width=W; full.height=H;
+  full.getContext('2d').drawImage(vidEl,0,0);
+  let ew,eh,L0,R0;
+  if(layout==='tb'){ ew=W; eh=H>>1; L0=[0,0]; R0=[0,eh]; }
+  else { ew=W>>1; eh=H; L0=[0,0]; R0=[ew,0]; }
+  if(swap){ const t=L0; L0=R0; R0=t; }
+  const scale=Math.min(1,420/ew);
+  const w=Math.round(ew*scale), h=Math.round(eh*scale);
+  const gc=document.createElement('canvas'); gc.width=w; gc.height=h;
+  const gctx=gc.getContext('2d',{willReadFrequently:true});
+  const grayOf=o=>{
+    gctx.drawImage(full,o[0],o[1],ew,eh,0,0,w,h);
+    const d=gctx.getImageData(0,0,w,h).data, g=new Uint8Array(w*h);
+    for(let i=0;i<g.length;i++) g[i]=(d[i*4]*77+d[i*4+1]*150+d[i*4+2]*29)>>8;
+    return g;
+  };
+  const L=grayOf(L0), R=grayOf(R0);
+  const range=Math.max(8,Math.round(w*0.08)), B=3;
+  const disp=new Float32Array(w*h).fill(-range-1);
+  const status=t=>{ const el=$('stereo-status'); el.textContent=t; el.hidden=false; };
+  const tick=()=>new Promise(r=>setTimeout(r));
+  for(let y=B;y<h-B;y++){
+    for(let x=B;x<w-B;x++){
+      let best=Infinity,bd=0;
+      for(let d=-range;d<=range;d++){
+        const xr=x-d;
+        if(xr-B<0||xr+B>=w) continue;
+        let sad=0;
+        for(let dy=-B;dy<=B&&sad<best;dy++){
+          const lo=(y+dy)*w+x, ro=(y+dy)*w+xr;
+          for(let dx=-B;dx<=B;dx++) sad+=Math.abs(L[lo+dx]-R[ro+dx]);
+        }
+        if(sad<best){ best=sad; bd=d; }
+      }
+      disp[y*w+x]=bd;
+    }
+    if((y&15)===0){ status(`matching… ${Math.round(100*y/h)}%`); await tick(); }
+  }
+  // percentile normalization so a few bad matches don't crush the range
+  const valid=[];
+  for(let i=0;i<disp.length;i++) if(disp[i]>=-range) valid.push(disp[i]);
+  valid.sort((a,b)=>a-b);
+  const p2=valid[Math.floor(valid.length*0.02)]||-range;
+  const p98=valid[Math.floor(valid.length*0.98)]||range;
+  const span=Math.max(1e-6,p98-p2);
+  const gray=new Uint8Array(w*h);
+  for(let i=0;i<disp.length;i++){
+    const v=disp[i]<-range?p2:disp[i];
+    gray[i]=Math.max(0,Math.min(255,Math.round((v-p2)/span*255)));
+  }
+  status(`done — disparity range ${p2.toFixed(1)}…${p98.toFixed(1)} px at ${w}×${h}`);
+  grayResult={gray,w,h};
+  selected={kind:'stereo-frame',label:'computed stereo disparity',
+    urn:'(SAD block matching of stereo pair)',
+    extra:{video_time_s:+vidEl.currentTime.toFixed(3),layout,swap_eyes:swap,
+      search_range_px:range,block:'7x7',working_width:w,
+      normalization:`2-98 percentile, ${p2.toFixed(1)}..${p98.toFixed(1)} px`}};
+  $('interp').value='disparity'; $('invert').checked=false;
+  renderSelected();
+  ['preview-wrap','interp-row','btn-png','btn-json'].forEach(id=>show(id,true));
+  show('btn-raw',false);
+}
+
 /* ── hand-written 16-bit grayscale PNG ── */
 
 const CRC_TABLE=(()=>{
@@ -789,7 +1043,9 @@ function exportJson(){
   const meta={
     tool:'https://e-z-g.github.io/spatialize.html',
     source_file:xFile.name,
-    source:selected.kind==='jpeg-sub'?'JPEG appended sub-image':'HEIC auxiliary item',
+    source:{ 'jpeg-sub':'JPEG appended sub-image',
+             'heic-aux':'HEIC auxiliary item',
+             'stereo-frame':'disparity computed from a stereo video frame' }[selected.kind],
     aux_type_urn:selected.urn||null,
     width:grayResult.w, height:grayResult.h,
     interpretation:interp,
@@ -797,7 +1053,10 @@ function exportJson(){
     inverted:inv,
     source_bit_depth:8,
     png_mapping:'png16 = source8 * 257'+(inv?' (after inversion)':''),
-    note:'8-bit source passed through the browser YUV-to-RGB path; treat values as relative, not metric.'
+    ...(selected.extra||{}),
+    note:selected.kind==='stereo-frame'
+      ?'Winner-take-all block matching, no smoothing; treat values as relative, not metric.'
+      :'8-bit source passed through the browser YUV-to-RGB path; treat values as relative, not metric.'
   };
   dlBlob(baseName(xFile.name)+'-depth.json',
     new Blob([JSON.stringify(meta,null,2)],{type:'application/json'}));

--- a/spatialize.html
+++ b/spatialize.html
@@ -81,6 +81,33 @@
       Research-grade, not Apple-grade: it's honest window matching, no
       smoothing, no ML. Near objects come out bright.
 
+  PREVIEWING IT, AND THE "HOLD THE STILL" TRICK
+  ─────────────────────────────────────────────
+  Panel 3 renders the parallax itself, so you can see what the depth map
+  actually buys you before shipping anything: a triangle-grid mesh in
+  WebGL, displaced horizontally by the depth texture in the vertex shader.
+  Rubber-sheet stretching across depth discontinuities is what fills the
+  disocclusions — the same visual compromise every 2D-plus-depth viewer
+  makes, and the reason edges smear when you push depth too far.
+
+  The export answers a real asymmetry: Facebook takes *video* everywhere,
+  but a still with a depth map has nowhere to go on the feed (the old
+  "3D photo" upload path is long past its heyday and Stories dropped it).
+  So we hold the still: render N seconds of it into a canvas stream and
+  record. Three shapes come out of the same renderer —
+
+    • flat hold      — no depth needed at all. A still, held, as a normal
+                       video file. This is the one that always uploads.
+    • wiggle         — camera oscillates; reads as 3-D to any flat viewer,
+                       which is what a phone or desktop feed actually is.
+    • side-by-side   — left and right eyes into one 2W×H frame, held. The
+                       shape Quest and every SBS player understands.
+
+  Recording is MediaRecorder over canvas.captureStream. MP4/H.264 is
+  requested first because that is what Meta ingests most happily; where
+  the browser only offers WebM the tool says so rather than pretending.
+  Dimensions are forced even — H.264 refuses odd ones.
+
   Everything runs locally; nothing is uploaded anywhere.
 -->
 <style>
@@ -148,6 +175,62 @@
     </div>
   </div>
 
+  <div class="card" id="panel3">
+    <div class="card-title">3 · Preview the effect, and hold it as a video</div>
+    <p class="card-desc">See the parallax live, then record it — a held still uploads anywhere, a wiggle reads as 3-D on a flat feed, side-by-side is what Quest wants.</p>
+
+    <div class="grid" style="margin-bottom:1rem">
+      <div>
+        <div class="drop-zone" id="dz-color" onclick="document.getElementById('fi-color').click()">
+          <p><strong>Picture</strong></p><p>the colour image</p>
+        </div>
+        <input type="file" id="fi-color" accept="image/*" onchange="loadColor(this.files[0])">
+        <div class="file-name" id="fn-color" hidden></div>
+        <button class="ghost-btn" id="btn-use-panel1" hidden onclick="usePanel1Image()">Use the image from panel 1</button>
+      </div>
+      <div>
+        <div class="drop-zone" id="dz-depth" onclick="document.getElementById('fi-depth').click()">
+          <p><strong>Depth map</strong> <span style="color:#555">(optional)</span></p><p>grayscale, near = bright</p>
+        </div>
+        <input type="file" id="fi-depth" accept="image/*" onchange="loadDepth(this.files[0])">
+        <div class="file-name" id="fn-depth" hidden></div>
+        <button class="ghost-btn" id="btn-use-panel2" hidden onclick="useExtractedDepth()">Use the depth from panel 2</button>
+      </div>
+    </div>
+
+    <div class="preview-wrap" id="gl-wrap" hidden><canvas id="gl"></canvas></div>
+
+    <div class="row" id="depth-controls" hidden>
+      <label for="strength">Depth</label>
+      <input type="range" id="strength" min="0" max="100" value="35" style="flex:1;min-width:8rem" oninput="syncPreview()">
+      <label style="min-width:auto"><input type="checkbox" id="depth-invert" onchange="rebuildDepthTexture()"> invert</label>
+      <label style="min-width:auto"><input type="checkbox" id="depth-smooth" checked onchange="rebuildDepthTexture()"> smooth</label>
+    </div>
+    <div class="row" id="conv-row" hidden>
+      <label for="conv">Focus plane</label>
+      <input type="range" id="conv" min="0" max="100" value="50" style="flex:1;min-width:8rem" oninput="syncPreview()">
+      <span id="conv-label" style="color:#777">mid</span>
+    </div>
+
+    <div class="row">
+      <label for="hold-sec">Hold for</label>
+      <input type="range" id="hold-sec" min="1" max="30" value="6" style="flex:1;min-width:8rem" oninput="document.getElementById('hold-label').textContent=this.value+'s'">
+      <span id="hold-label" style="color:#777">6s</span>
+    </div>
+    <div class="row">
+      <label for="out-mode">Export as</label>
+      <select id="out-mode">
+        <option value="flat">flat hold — no depth needed</option>
+        <option value="wiggle">wiggle parallax</option>
+        <option value="sbs">side-by-side stereo</option>
+      </select>
+    </div>
+
+    <button class="process-btn" id="btn-record" disabled onclick="recordHold()">Record video</button>
+    <div class="ok-msg" id="rec-status" hidden></div>
+    <div class="error-msg" id="rec-err" hidden></div>
+  </div>
+
   <div class="card about-card">
     <div class="card-title">The pipeline, and what’s honestly possible</div>
     <p class="card-desc">Read this once before blaming the tool</p>
@@ -161,7 +244,8 @@
       <strong>Toggle still not showing?</strong> The gate is not only metadata. Known additional requirements, all reported in the wild: the phone must be on <em>Wi-Fi</em> (mobile data silently fails), <em>Reduce Motion</em> must be off (Settings → Accessibility → Motion), the <em>full-resolution original</em> must be on the device (with iCloud-optimized storage, open the photo and start-then-cancel an edit to force the download), and it takes an iPhone 12 or newer on iOS 26. Photos may also need a little time after import before the option appears. Work through that list before blaming the EXIF.<br><br>
       <strong>Getting depth out:</strong> the Spatial Scene depth map itself never leaves the phone — Photos renders it live and exports no file containing it. What <em>is</em> extractable, and what panel 2 reads: Portrait-mode shots (HEIC aux disparity image, or the extra JPEGs appended to a shared Portrait JPEG), HDR gain maps, and segmentation mattes. Export the <em>unmodified original</em> from Photos, or AirDrop to a Mac — “most compatible” conversions usually strip the aux images.<br><br>
       <strong>Output format:</strong> 16-bit grayscale PNG, values scaled ×257 from the 8-bit source, plus a JSON sidecar naming the source urn and whether bright means near (disparity) or far (depth). That pair drops straight into MiDaS-style depth pipelines.<br><br>
-      <strong>Spatial / Facebook & Meta video:</strong> Meta's side takes stereo video as Apple MV-HEVC (uploaded through the Meta Quest app; a Facebook feed post just shows it flat) or as plain full side-by-side video. Drop a .MOV/.MP4 above and the tool reads the stereo boxes — Apple's <code>vexu</code> (eyes, baseline, disparity adjustment) and the <code>st3d</code> SBS/TB tag — even when the browser can't play the codec. MV-HEVC's second eye is beyond every browser decoder, so flatten to SBS first (<code>ffmpeg</code> 7.1+ decodes MV-HEVC, or Spatialify on iOS) and feed the SBS back in: then you can grab a frame, split the eyes, and compute a real disparity map by block matching, exported in the same 16-bit PNG + JSON format. Facebook's old “3D photo” post type (2D + depth pair) was retired, so there is nothing left to inject depth into on the feed side.<br><br>
+      <strong>Spatial / Facebook & Meta video:</strong> Meta's side takes stereo video as Apple MV-HEVC (uploaded through the Meta Quest app; a Facebook feed post just shows it flat) or as plain full side-by-side video. Drop a .MOV/.MP4 above and the tool reads the stereo boxes — Apple's <code>vexu</code> (eyes, baseline, disparity adjustment) and the <code>st3d</code> SBS/TB tag — even when the browser can't play the codec. MV-HEVC's second eye is beyond every browser decoder, so flatten to SBS first (<code>ffmpeg</code> 7.1+ decodes MV-HEVC, or Spatialify on iOS) and feed the SBS back in: then you can grab a frame, split the eyes, and compute a real disparity map by block matching, exported in the same 16-bit PNG + JSON format. Facebook's own “3D photo” upload path (2D + depth pair) is long past its heyday — Stories dropped it and it is not something to build on now — so panel 3 goes the other way and hands Meta what it reliably eats: video.<br><br>
+      <strong>Panel 3 — preview, and the hold:</strong> load a picture (plus a depth map, if you have one) to see the parallax rendered live, then record it. <em>Flat hold</em> needs no depth at all: it is your still, held for N seconds, as an ordinary video — the thing that uploads anywhere, and what Quest's own photo-to-3D conversion can then chew on. <em>Wiggle</em> oscillates the camera, which is what actually reads as three-dimensional to a phone or desktop feed, since a flat viewer never sees a second eye. <em>Side-by-side</em> writes both eyes into one frame for Quest and any SBS player. MP4/H.264 is requested first because Meta ingests it most happily; if your browser only offers WebM the tool tells you, and <code>ffmpeg -i in.webm -c:v libx264 -pix_fmt yuv420p out.mp4</code> finishes the job. No depth map to hand? Pull one from a Portrait shot above, from a stereo video above, or from any monocular depth model — the 16-bit PNG this tool exports is the same format they emit.<br><br>
       HEIC decoding uses WebCodecs HEVC — works in Safari and in Chrome on hardware with an HEVC decoder. Where it can’t decode, the tool still lists the file’s contents and hands you the raw HEVC payload for <code>heif-convert --with-aux</code> or <code>ffmpeg</code>. Everything runs locally; nothing is uploaded.
     </div>
   </div>
@@ -353,6 +437,7 @@ async function buildCameraJpeg(){
     const out=concatBytes([jpeg.subarray(0,2),app1,jpeg.subarray(2)]);
     outJpeg={name:baseName(inFile.name)+'-camera.jpg', blob:new Blob([out],{type:'image/jpeg'})};
     show('btn-dl-jpeg',true);
+    syncHandoffButtons();
     setMsg('ok-in',`Wrote ${bmp.width}×${bmp.height} JPEG with Apple/iPhone 15 Pro EXIF, DateTimeOriginal ${exifDateString(when)}. AirDrop or save it into Photos, then look for the spatial toggle.`);
   }catch(e){
     setMsg('err-in',e.message);
@@ -656,6 +741,7 @@ async function selectPayload(i,btn){
     }
     renderSelected();
     ['preview-wrap','interp-row','btn-png','btn-json'].forEach(id=>show(id,true));
+    syncHandoffButtons();
   }catch(e){
     ['preview-wrap','interp-row','btn-png','btn-json'].forEach(id=>show(id,false));
     setMsg('err-x',e.message+(selected.kind==='heic-aux'?'\nYou can still download the raw HEVC payload below and finish with: heif-convert --with-aux in.heic out.jpg':''));
@@ -968,6 +1054,402 @@ async function computeStereoDepth(){
   renderSelected();
   ['preview-wrap','interp-row','btn-png','btn-json'].forEach(id=>show(id,true));
   show('btn-raw',false);
+  syncHandoffButtons();
+}
+
+/* ───────────────── panel 3: preview, and hold it as video ─────────────────
+   A 2D-plus-depth viewer. The mesh is a triangle grid over the image; the
+   vertex shader pushes each vertex sideways by (depth - focus) * strength *
+   shift. Near geometry therefore slides opposite to the camera, and the
+   triangles spanning a depth edge stretch to cover what would otherwise be
+   a hole. That rubber-sheeting is the whole trick — and the reason edges
+   smear once you push Depth past about two thirds.
+
+   Shift convention matches the block matcher above: a near point sits
+   further LEFT in the right eye, so the left eye renders with shift = +amp
+   and the right with -amp. Feeding this panel's own SBS export back into
+   panel 2 recovers the depth it started from, which is how it's tested. */
+
+const VS = `
+precision highp float;
+attribute vec2 a_uv;
+uniform sampler2D u_depth;
+uniform float u_shift, u_strength, u_conv, u_zoom;
+varying vec2 v_uv;
+void main(){
+  float d = texture2D(u_depth, a_uv).r;
+  vec2 p = vec2(a_uv.x*2.0-1.0, 1.0-a_uv.y*2.0) * u_zoom;
+  p.x += (d - u_conv) * u_strength * u_shift;
+  v_uv = a_uv;
+  gl_Position = vec4(p, 0.0, 1.0);
+}`;
+const FS = `
+precision highp float;
+varying vec2 v_uv;
+uniform sampler2D u_img;
+void main(){ gl_FragColor = texture2D(u_img, v_uv); }`;
+
+const pv = { img:null, depthData:null, gl:null, prog:null, u:{}, nIdx:0,
+             texImg:null, texDepth:null, raf:0, t0:0, recording:false, aspect:1 };
+
+const MAX_NDC_SHIFT = 0.22;   // strength slider 100 = 22% of frame width
+const WIGGLE_PERIOD = 3.2;    // seconds per full oscillation
+const SBS_AMP = 0.55;         // stereo baseline as a fraction of max shift
+
+['dz-color','dz-depth'].forEach(id=>{
+  const dz=$(id);
+  dz.addEventListener('dragover',e=>{e.preventDefault();dz.classList.add('drag-over');});
+  dz.addEventListener('dragleave',()=>dz.classList.remove('drag-over'));
+  dz.addEventListener('drop',e=>{
+    e.preventDefault(); dz.classList.remove('drag-over');
+    const f=e.dataTransfer.files[0];
+    if(f) (id==='dz-color'?loadColor:loadDepth)(f);
+  });
+});
+
+async function loadColor(f){
+  if(!f) return;
+  setMsg('rec-err','');
+  try{
+    pv.img=await createImageBitmap(f);
+    pv.aspect=pv.img.width/pv.img.height;
+    $('fn-color').textContent=`${f.name} — ${pv.img.width}×${pv.img.height}`;
+    show('fn-color',true);
+    startPreview();
+  }catch(e){ setMsg('rec-err','Could not decode that image: '+e.message); }
+}
+function usePanel1Image(){ if(inFile) loadColor(inFile); }
+
+async function loadDepth(f){
+  if(!f) return;
+  setMsg('rec-err','');
+  try{
+    const bmp=await createImageBitmap(f);
+    const c=document.createElement('canvas');
+    c.width=bmp.width; c.height=bmp.height;
+    const ctx=c.getContext('2d',{willReadFrequently:true});
+    ctx.drawImage(bmp,0,0);
+    const px=ctx.getImageData(0,0,bmp.width,bmp.height).data;
+    const g=new Uint8Array(bmp.width*bmp.height);
+    for(let i=0;i<g.length;i++) g[i]=px[i*4];
+    pv.depthData={gray:g,w:bmp.width,h:bmp.height};
+    $('fn-depth').textContent=`${f.name} — ${bmp.width}×${bmp.height}`;
+    show('fn-depth',true);
+    startPreview();
+  }catch(e){ setMsg('rec-err','Could not decode that depth map: '+e.message); }
+}
+function useExtractedDepth(){
+  if(!grayResult) return;
+  pv.depthData={gray:grayResult.gray.slice(),w:grayResult.w,h:grayResult.h};
+  $('fn-depth').textContent=`from panel 2 — ${grayResult.w}×${grayResult.h}`;
+  show('fn-depth',true);
+  startPreview();
+}
+// panel 2 / panel 1 can hand their results across; offer that when they exist
+function syncHandoffButtons(){
+  show('btn-use-panel2', !!grayResult);
+  show('btn-use-panel1', !!inFile);
+}
+
+function glInit(){
+  if(pv.gl) return true;
+  const c=$('gl');
+  // preserveDrawingBuffer: without it captureStream can grab a cleared
+  // buffer and record black frames — the classic canvas-recording trap
+  const opts={preserveDrawingBuffer:true,antialias:true};
+  const gl=c.getContext('webgl2',opts)||c.getContext('webgl',opts);
+  if(!gl){ setMsg('rec-err','WebGL is unavailable, so the preview cannot render.'); return false; }
+  if(gl.getParameter(gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS)<1){
+    setMsg('rec-err','This GPU cannot sample textures in a vertex shader, which the displacement needs.');
+    return false;
+  }
+  const sh=(type,src)=>{
+    const o=gl.createShader(type);
+    gl.shaderSource(o,src); gl.compileShader(o);
+    if(!gl.getShaderParameter(o,gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(o));
+    return o;
+  };
+  const prog=gl.createProgram();
+  gl.attachShader(prog,sh(gl.VERTEX_SHADER,VS));
+  gl.attachShader(prog,sh(gl.FRAGMENT_SHADER,FS));
+  gl.linkProgram(prog);
+  if(!gl.getProgramParameter(prog,gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(prog));
+  gl.useProgram(prog);
+
+  // grid mesh: N×N vertices of uv, indexed into triangles
+  const N=192, uv=new Float32Array(N*N*2);
+  for(let y=0,k=0;y<N;y++) for(let x=0;x<N;x++){ uv[k++]=x/(N-1); uv[k++]=y/(N-1); }
+  const idx=new Uint32Array((N-1)*(N-1)*6);
+  let k=0;
+  for(let y=0;y<N-1;y++) for(let x=0;x<N-1;x++){
+    const a=y*N+x, b=a+1, c2=a+N, d=c2+1;
+    idx[k++]=a; idx[k++]=c2; idx[k++]=b; idx[k++]=b; idx[k++]=c2; idx[k++]=d;
+  }
+  const ext = gl.getParameter(gl.VERSION).indexOf('WebGL 2')===0 ? true : gl.getExtension('OES_element_index_uint');
+  if(!ext) throw new Error('32-bit mesh indices unsupported');
+  const vb=gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER,vb);
+  gl.bufferData(gl.ARRAY_BUFFER,uv,gl.STATIC_DRAW);
+  const loc=gl.getAttribLocation(prog,'a_uv');
+  gl.enableVertexAttribArray(loc);
+  gl.vertexAttribPointer(loc,2,gl.FLOAT,false,0,0);
+  const ib=gl.createBuffer();
+  gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER,ib);
+  gl.bufferData(gl.ELEMENT_ARRAY_BUFFER,idx,gl.STATIC_DRAW);
+  pv.nIdx=idx.length;
+
+  for(const n of ['u_depth','u_img','u_shift','u_strength','u_conv','u_zoom'])
+    pv.u[n]=gl.getUniformLocation(prog,n);
+  gl.uniform1i(pv.u.u_img,0);
+  gl.uniform1i(pv.u.u_depth,1);
+  gl.clearColor(0,0,0,1);
+  pv.gl=gl; pv.prog=prog;
+  return true;
+}
+
+function makeTex(gl,unit){
+  const t=gl.createTexture();
+  gl.activeTexture(gl.TEXTURE0+unit);
+  gl.bindTexture(gl.TEXTURE_2D,t);
+  gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_S,gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_T,gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_MIN_FILTER,gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_MAG_FILTER,gl.LINEAR);
+  return t;
+}
+
+function boxBlur(gray,w,h,r){
+  const tmp=new Uint8Array(gray.length), out=new Uint8Array(gray.length);
+  for(let y=0;y<h;y++) for(let x=0;x<w;x++){
+    let s=0,n=0;
+    for(let d=-r;d<=r;d++){ const xx=x+d; if(xx>=0&&xx<w){ s+=gray[y*w+xx]; n++; } }
+    tmp[y*w+x]=s/n;
+  }
+  for(let y=0;y<h;y++) for(let x=0;x<w;x++){
+    let s=0,n=0;
+    for(let d=-r;d<=r;d++){ const yy=y+d; if(yy>=0&&yy<h){ s+=tmp[yy*w+x]; n++; } }
+    out[y*w+x]=s/n;
+  }
+  return out;
+}
+
+function rebuildDepthTexture(){
+  if(!pv.gl) return;
+  const gl=pv.gl;
+  const d=pv.depthData;
+  if(!pv.texDepth) pv.texDepth=makeTex(gl,1);
+  gl.activeTexture(gl.TEXTURE1);
+  gl.bindTexture(gl.TEXTURE_2D,pv.texDepth);
+  if(!d){ // flat: a single mid-grey texel, strength forced to 0 anyway
+    gl.texImage2D(gl.TEXTURE_2D,0,gl.RGBA,1,1,0,gl.RGBA,gl.UNSIGNED_BYTE,new Uint8Array([128,128,128,255]));
+    return;
+  }
+  let g=d.gray;
+  if($('depth-smooth').checked) g=boxBlur(g,d.w,d.h,Math.max(1,Math.round(d.w/240)));
+  const inv=$('depth-invert').checked;
+  const rgba=new Uint8ClampedArray(d.w*d.h*4);
+  for(let i=0;i<g.length;i++){
+    const v=inv?255-g[i]:g[i];
+    rgba[i*4]=rgba[i*4+1]=rgba[i*4+2]=v; rgba[i*4+3]=255;
+  }
+  gl.texImage2D(gl.TEXTURE_2D,0,gl.RGBA,d.w,d.h,0,gl.RGBA,gl.UNSIGNED_BYTE,new Uint8Array(rgba.buffer));
+  syncPreview();
+}
+
+function startPreview(){
+  syncHandoffButtons();
+  if(!pv.img){ $('btn-record').disabled=true; return; }
+  if(!glInit()) return;
+  const gl=pv.gl;
+  if(!pv.texImg) pv.texImg=makeTex(gl,0);
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D,pv.texImg);
+  gl.texImage2D(gl.TEXTURE_2D,0,gl.RGBA,gl.RGBA,gl.UNSIGNED_BYTE,pv.img);
+  rebuildDepthTexture();
+  const has=!!pv.depthData;
+  show('gl-wrap',true);
+  show('depth-controls',has);
+  show('conv-row',has);
+  $('out-mode').querySelectorAll('option').forEach(o=>{
+    if(o.value!=='flat') o.disabled=!has;
+  });
+  if(!has) $('out-mode').value='flat';
+  $('btn-record').disabled=false;
+  sizeCanvas(Math.min(760,pv.img.width));
+  syncPreview();
+  // only animate when there is depth to animate; a flat picture is drawn
+  // once rather than burning a redraw every frame forever
+  if(has){ if(!pv.raf){ pv.t0=performance.now(); loopPreview(); } }
+  else { if(pv.raf){ cancelAnimationFrame(pv.raf); pv.raf=0; } drawFrame('flat',0); }
+}
+
+function sizeCanvas(w,sbs){
+  const c=$('gl');
+  const h=Math.max(2,Math.round(w/pv.aspect)&~1);
+  c.width=(sbs?w*2:w)&~1; c.height=h;
+  c.style.width='100%'; c.style.height='auto';
+}
+
+function syncPreview(){
+  if(!pv.gl) return;
+  const gl=pv.gl;
+  const strength=pv.depthData?(+$('strength').value/100)*MAX_NDC_SHIFT:0;
+  const conv=+$('conv').value/100;
+  gl.uniform1f(pv.u.u_strength,strength);
+  gl.uniform1f(pv.u.u_conv,conv);
+  // zoom just enough that the sideways push never uncovers the frame edge
+  gl.uniform1f(pv.u.u_zoom,1+strength*Math.max(conv,1-conv));
+  $('conv-label').textContent=conv<0.34?'near':conv>0.66?'far':'mid';
+}
+
+function drawView(shift,x,y,w,h){
+  const gl=pv.gl;
+  gl.viewport(x,y,w,h);
+  gl.uniform1f(pv.u.u_shift,shift);
+  gl.drawElements(gl.TRIANGLES,pv.nIdx,gl.UNSIGNED_INT,0);
+}
+function drawFrame(mode,tSec){
+  const gl=pv.gl, c=$('gl');
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  if(mode==='sbs'){
+    const half=c.width>>1;
+    drawView(+SBS_AMP,0,0,half,c.height);
+    drawView(-SBS_AMP,half,0,half,c.height);
+  }else if(mode==='wiggle'){
+    drawView(Math.sin(tSec/WIGGLE_PERIOD*2*Math.PI),0,0,c.width,c.height);
+  }else{
+    drawView(0,0,0,c.width,c.height);
+  }
+}
+function loopPreview(){
+  pv.raf=requestAnimationFrame(loopPreview);
+  if(pv.recording) return;                    // the recorder drives the canvas
+  const t=(performance.now()-pv.t0)/1000;
+  drawFrame(pv.depthData?'wiggle':'flat',t);
+}
+
+/* ── recording: hold the canvas for N seconds and capture it ── */
+
+function pickMime(){
+  if(typeof MediaRecorder==='undefined') return null;
+  const want=['video/mp4;codecs=avc1.4d002a','video/mp4;codecs=avc1.42E01E','video/mp4',
+              'video/webm;codecs=h264','video/webm;codecs=vp9','video/webm'];
+  return want.find(t=>MediaRecorder.isTypeSupported(t))||null;
+}
+
+/* MediaRecorder gives no frame-level feedback: if the encoder cannot keep
+   up it silently drops frames, and the muxer stamps each SURVIVING frame at
+   1/fps — so the file comes out short rather than choppy. A 3s hold arrived
+   as 1.5s under software rendering: 90 frames pushed, 45 landed.
+
+   That ratio is the clue. Duration follows the frame COUNT that survives,
+   not wall-clock time, so the cure is not to push more frames (which only
+   drops a bigger fraction) but to push the same frames more SLOWLY and let
+   the encoder drain. Each retry halves the push rate, keeping the frame
+   budget fixed: the recording takes longer in real time and lands on the
+   full requested duration. On hardware that keeps up, pass one is already
+   exact and none of this fires. */
+
+function probeDuration(blob){
+  return new Promise(res=>{
+    const v=document.createElement('video');
+    v.preload='metadata'; v.muted=true;
+    let settled=false;
+    const done=d=>{ if(settled) return; settled=true; URL.revokeObjectURL(v.src); res(d||0); };
+    v.onloadeddata=()=>{
+      if(isFinite(v.duration)&&v.duration>0) return done(v.duration);
+      // MediaRecorder WebM reports Infinity until it has been seeked
+      v.onseeked=()=>done(isFinite(v.duration)?v.duration:0);
+      v.currentTime=1e6;
+    };
+    v.onerror=()=>done(0);
+    v.src=URL.createObjectURL(blob);
+    setTimeout(()=>done(0),8000);
+  });
+}
+
+async function captureFrames(mode,frames,fps,mime,bitrate,paceFps){
+  const stream=$('gl').captureStream(0);
+  const track=stream.getVideoTracks()[0];
+  const manual=typeof track.requestFrame==='function';
+  const rec=new MediaRecorder(stream,{mimeType:mime,videoBitsPerSecond:bitrate});
+  const chunks=[];
+  rec.ondataavailable=e=>{ if(e.data.size) chunks.push(e.data); };
+  const done=new Promise(r=>{ rec.onstop=r; });
+  const t0=performance.now();
+  rec.start();
+  for(let i=0;i<frames;i++){
+    const wait=t0+i*1000/(paceFps||fps)-performance.now();
+    if(wait>1) await new Promise(r=>setTimeout(r,wait));
+    // Redraw every frame even for a motionless hold: the capture pipeline
+    // only yields a frame when the canvas is actually repainted, so skipping
+    // the redraw for static content produced single-frame files.
+    drawFrame(mode,i/fps);
+    if(manual) track.requestFrame();
+    $('btn-record').textContent=`Recording… ${Math.round(100*(i+1)/frames)}%`;
+  }
+  rec.stop();
+  await done;
+  stream.getTracks().forEach(t=>t.stop());
+  return new Blob(chunks,{type:mime.split(';')[0]});
+}
+
+async function recordHold(){
+  if(!pv.img||pv.recording) return;
+  setMsg('rec-err',''); setMsg('rec-status','');
+  const mime=pickMime();
+  if(!mime){ setMsg('rec-err','MediaRecorder is unavailable in this browser, so nothing can be recorded.'); return; }
+  const mode=$('out-mode').value, secs=+$('hold-sec').value, fps=30;
+  const eyeW=Math.min(pv.img.width, mode==='sbs'?1280:1920)&~1;
+  sizeCanvas(eyeW, mode==='sbs');
+  syncPreview();
+
+  pv.recording=true;
+  $('btn-record').disabled=true;
+  // resizing a canvas clears it, so paint the real first frame BEFORE the
+  // recorder starts — otherwise frame 0 is black and every held video opens
+  // on a flash of nothing
+  drawFrame(mode,0);
+
+  const bitrate=mode==='sbs'?16e6:10e6;
+  const frames=Math.round(secs*fps);
+  let blob=null, dur=0, passes=0, pace=fps;
+  try{
+    for(let attempt=0;attempt<2;attempt++){
+      passes++;
+      const take=await captureFrames(mode,frames,fps,mime,bitrate,pace);
+      if(take&&take.size){
+        const d=await probeDuration(take);
+        // keep whichever take lands closest to the length asked for — never
+        // throw away a good one because a later attempt came back empty
+        if(!blob||Math.abs((d||0)-secs)<Math.abs(dur-secs)){ blob=take; dur=d; }
+        if(d&&d>=secs*0.9&&d<=secs*1.2) break;
+      }
+      pace=pace/2;               // let the encoder drain; frame budget unchanged
+    }
+  }catch(e){
+    setMsg('rec-err','Recording failed: '+e.message);
+  }
+  pv.recording=false;
+  $('btn-record').disabled=false;
+  $('btn-record').textContent='Record video';
+  if(!blob||!blob.size){ setMsg('rec-err','The recorder produced no data.'); return; }
+
+  const ext=mime.startsWith('video/mp4')?'mp4':'webm';
+  const label={flat:'hold',wiggle:'wiggle',sbs:'sbs'}[mode];
+  const base=inFile?baseName(inFile.name):'spatial';
+  dlBlob(`${base}-${label}.${ext}`,blob);
+  const size=(blob.size/1048576).toFixed(1);
+  const dims=mode==='sbs'?`${eyeW*2}×${$('gl').height} side-by-side`:`${eyeW}×${$('gl').height}`;
+  setMsg('rec-status',
+    `${dur?dur.toFixed(1)+'s':secs+'s'} · ${dims} · ${size} MB · ${mime.split(';')[0]}`
+    + (passes>1?` · re-recorded ${passes-1}× to make the duration`:'')
+    + (dur&&Math.abs(dur-secs)>secs*0.15?`\nThe encoder could not hold the pace exactly, so this came out ${dur.toFixed(1)}s rather than ${secs}s. It is a valid video either way — for a closer match try a shorter hold or a smaller picture.`:'')
+    + (ext==='webm'?'\nThis browser only records WebM. Facebook prefers MP4 — convert with:\nffmpeg -i in.webm -c:v libx264 -pix_fmt yuv420p -movflags +faststart out.mp4':'')
+    + (mode==='sbs'?'\nSBS is not self-describing: in a Quest player pick side-by-side, or tag it with ffmpeg -vf stereo3d or a spatial-media injector.':''));
+
+  sizeCanvas(Math.min(760,pv.img.width));    // restore the preview size
+  syncPreview();
 }
 
 /* ── hand-written 16-bit grayscale PNG ── */


### PR DESCRIPTION
Follow-on to #29, which added the Spatial Photo Kit. Two commits, both in `spatialize.html`.

## Spatial / stereo video (`b89036e`)

The extraction panel now takes `.MOV`/`.MP4`:

- Parses the stereo boxes — Apple's `vexu` (eye flags, hero eye, baseline in µm, disparity adjustment) and the `st3d` SBS/top-bottom tag — **even when the browser cannot play the codec at all**, so an MV-HEVC file still tells you what it is.
- Says plainly that MV-HEVC's second eye is beyond every browser decoder, and how to flatten it (`ffmpeg` 7.1+, or Spatialify on iOS).
- For any stereo video the browser *can* play: grab a frame, split the eyes, and compute a real disparity map with a SAD block matcher (7×7 windows, ±8% search, 2–98 percentile normalization). Exported through the existing 16-bit PNG + JSON path.

Also adds the field-reported Spatial Scene checklist to the About card — Wi-Fi, Reduce Motion off, full-resolution original on device — since camera-shaped EXIF alone does not always flip the toggle.

## Preview, and holding a still (`067d9cc`)

Facebook reliably ingests video; a still plus a depth map has no dependable upload path. So panel 3 renders the effect and then records it.

- **Preview**: a triangle-grid mesh displaced horizontally by the depth map in a vertex shader. Rubber-sheet stretching across depth edges fills the disocclusions — the same compromise every 2D-plus-depth viewer makes, and it shows where a depth map falls apart before you commit to it.
- **Flat hold** — needs no depth map at all. The still, held, as an ordinary MP4: the file that uploads anywhere.
- **Wiggle** — oscillating camera; what actually reads as three-dimensional on the flat viewer a phone or desktop feed is.
- **Side-by-side** — both eyes in one frame, for Quest and SBS players.

MP4/H.264 is requested first, with the `ffmpeg` conversion line surfaced when a browser only offers WebM.

## Testing

Driven headlessly through the real UI in Chromium.

- **Round trip**: a synthesized image + depth map with a near square → SBS export → fed back through the block matcher → recovers `−11…+20 px` disparity, foreground 189 vs background 0. Depth survives the whole loop, which also proves the renderer and matcher agree on eye ordering and sign.
- **Box parser**: synthetic spatial MOV (`stri` left+right, 19.24 mm baseline, `dadj` 0.02, `lhvC`, `st3d`=SBS) — every field read back correctly.
- **Regression**: the EXIF writer, 16-bit PNG encoder, JPEG sub-image scanner and HEIC aux parser from #29 all still pass. A bit-reversal bug in the HEVC codec-string builder was caught and fixed earlier against Apple's known `hvc1.1.6.L93.B0`.

Three real bugs surfaced and were fixed during testing: resizing the canvas clears it, so every exported video began on a **black frame**; a motionless hold produced **single-frame files**, because the capture pipeline only yields a frame on repaint; and the muxer stamps surviving frames at a fixed rate, so dropped frames **shorten** the file rather than stuttering it.

## Known limitation

Exact export duration depends on the encoder keeping pace. The recorder measures what it actually produced, retries once at half push-rate, keeps whichever take lands closest, and **reports the real duration rather than the requested one** (verified: claims 0.8 s for a 0.84 s file). In this environment — software rendering, no GPU, and no H.264 encoder available for a WebCodecs alternative — the SBS export still lands short of a 3 s request. On real hardware the first pass should be exact, but that is the one claim not verified here. If it proves short in practice, the fix is a WebCodecs encoder with a hand-written MP4 muxer, which would make duration exact by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kgfpyky61JMbGffADjW26P

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgfpyky61JMbGffADjW26P)_