### PR TITLE
A quieter page, a button worth pressing, and two ideas measured and deleted

### DIFF
--- a/gifsmash.html
+++ b/gifsmash.html
@@ -67,6 +67,49 @@
   already arrived. Both are now options, both default to the better
   behaviour, and both can be turned off to get the script's output.
 
+  TRIED AND REJECTED: A ROOT FIND INSTEAD OF THE LOOP
+  ---------------------------------------------------
+  Approx mode looks indefensible. It is a proportional controller whose
+  gain is the literal constant 2, and it rings around the target rather
+  than converging — 83% of target, then 116%, then 101%, then 84% on a
+  real clip. The obvious fix is to stop steering four knobs and steer
+  one: every knob is monotone in the same direction, so collapse them
+  onto a single quality scalar, let the weights be the shape of the
+  descent, and solve for the scalar that hits the number with a
+  bracketed secant. That was built, measured against approx over ten
+  source-and-target pairs, and deleted.
+
+    approx  10/10 fits, 4.3 encodes, 83% of target reached
+    search  10/10 fits, 4.6 encodes, 77% of target reached
+
+  It converged tidily and handed back a smaller, worse file every time.
+  The reason is that GIF size against quality is not a curve, it is a
+  staircase: colours and lossiness move in integer steps and the palette
+  is rebuilt from scratch at each one, so the smooth local behaviour a
+  secant method assumes is not there. Approx's untidy overshooting
+  samples that staircase in several places, and keep-best takes the good
+  sample — so the ringing that looks like the flaw is doing the work.
+
+  Do not rebuild it without beating those numbers first.
+
+  ALSO REJECTED: THE OTHER TWO READINGS OF weightSum
+  ---------------------------------------------------
+  The script computes weightSum as the sum of the four weights and then
+  overwrites it with the literal 2.00 one line later, so every weight is
+  halved regardless of the others. Both other readings — divide by the
+  actual sum, which is what the overwritten line computed, or divide by
+  nothing — shipped as options until they were measured over thirty
+  runs:
+
+    approx  halved   10/10 fits, 83% of target reached
+    approx  shared    3/10 fits, 53%
+    approx  as-given 10/10 fits, 33%
+
+  Shared cannot hit a target. As-given hits it by overshooting so far
+  down that two thirds of the budget is thrown away. The accident is
+  better than either thing it might have been, so the divisor is 2 and
+  there is no control for it.
+
   NO CDN. Everything below is hand-written and the page works from
   file:// — including the compressor, which runs in a worker built out
   of this page's own <script> text when the browser allows it and falls
@@ -209,8 +252,6 @@
   }
   button:hover:not(:disabled) { border-color: #4a4a4a; background: #232323; }
   button:disabled { opacity: .4; cursor: default; }
-  button.primary { background: #1d4a7a; border-color: #2a6299; color: #eaf3ff; font-weight: 600; }
-  button.primary:hover:not(:disabled) { background: #23578c; border-color: #3573b0; }
   button.danger { border-color: #5c3535; color: #e6b3b3; }
 
   .seg { display: inline-flex; border: 1px solid var(--line-2); border-radius: 6px; overflow: hidden; }
@@ -588,30 +629,22 @@
             <label class="name">Mode</label>
             <div class="seg" id="modeSeg">
               <button type="button" data-mode="approx" class="on">Approximate</button>
-              <button type="button" data-mode="search">Search</button>
               <button type="button" data-mode="threshold">Threshold</button>
             </div>
           </div>
           <p class="hint full" id="modeHint">Feeds each result back in: overshoot by 2× and the
             next iteration cuts twice as hard. Lands close to the target from either side.</p>
           <div class="info" id="i-loop" hidden>
-            <p><b>Approximate</b> is the script's, and the default because it measurably wins.
-               It corrects each knob by its own function of one ratio, overshoots, and comes
-               back — which looks untidy in the log and does not matter, because keep-best
-               holds the good pass. Across ten source-and-target combinations it fitted 10/10
-               in 4.3 encodes, landing at 83% of the target on average.</p>
-            <p><b>Search</b> collapses the four knobs onto a single quality scalar and finds
-               the target by secant root-finding, with a bracket so it cannot diverge. It is
-               the tidier algorithm and it lost: 10/10 fits, 4.6 encodes, 77% utilisation. GIF
-               size against quality is not smooth enough for a root finder — colours and
-               lossiness move in integer steps and the palette is rebuilt from scratch each
-               time — and approximate's untidy exploring copes with that better than
-               convergence does. Kept because it always brackets, so it can tell you a target
-               is impossible rather than just failing to reach it.</p>
-            <p><b>Threshold</b> is the script's other mode and the weak one: no feedback at
-               all, every knob walking to its limit on a fixed schedule. It missed 4 of those
-               10 targets outright while spending 9.1 encodes doing it. Use it when you want
-               a predictable ramp rather than a result.</p>
+            <p><b>Approximate</b> is the default because it measurably wins. It corrects each
+               knob by its own function of one ratio, overshoots, and comes back — which looks
+               untidy in the log and does not matter, because keep-best holds the good pass.
+               Across ten source-and-target combinations it fitted 10 out of 10 in 4.3 encodes,
+               landing at 83% of the target on average.</p>
+            <p><b>Threshold</b> is the weak one: no feedback at all, every knob walking to its
+               limit on a fixed schedule. It missed 4 of those 10 targets outright while
+               spending 9.1 encodes doing it. It is here because it is what the script did, and
+               because a predictable ramp is occasionally what you want. It is not what you
+               want if you want a result.</p>
             <p><b>Keep best</b> holds whichever pass landed closest under the target rather
                than whichever ran last. The script always shipped the last one, so a pass that
                overshot after a good one threw the good one away. Turn it off to reproduce
@@ -619,11 +652,10 @@
                this much of it; 0 spends every iteration. A run also stops early when a result
                fits with every knob still at its starting value — there is nothing left to
                hand back.</p>
-            <p><b>Weights</b> were divided by 2 by the script no matter what the others were,
-               so weight 1 closes half the gap. Sharing divides by the sum of the four, which
-               is what the line it overwrote computed. As-given divides by nothing. In search
-               mode only the ratios matter — the weights are the mix, and the search decides
-               the amount.</p>
+            <p><b>Weights</b> are divided by 2 no matter what the others are set to, so a
+               weight of 1 closes half the gap rather than all of it. That is the script's
+               arithmetic, and the two other readings of it were tried and measured worse —
+               see the comment at the top of this file.</p>
           </div>
           <div class="row">
             <label class="name" for="maxIter">Iterations</label>
@@ -636,13 +668,6 @@
           <div class="row wide"><label class="name" for="tolPct">Stop within</label>
             <input type="number" id="tolPct" value="2" min="0" max="50" step="0.5" />
             <span class="hint full" style="margin:0">% under target — 0 runs every iteration</span>
-          </div>
-          <div class="row wide"><label class="name" for="normMode">Weights are</label>
-            <select id="normMode" class="grow">
-              <option value="half" selected>halved — as the script shipped</option>
-              <option value="sum">shared across the four</option>
-              <option value="none">used as given</option>
-            </select>
           </div>
         </div>
       </details>
@@ -936,7 +961,7 @@
         <div class="empty" id="logEmpty">Each pass prints the settings it tried and what they weighed.</div>
         <table class="log" id="logTable" style="display:none">
           <thead><tr>
-            <th>#</th><th>q</th><th>fps</th><th>lossy</th><th>scale</th><th>colours</th>
+            <th>#</th><th>fps</th><th>lossy</th><th>scale</th><th>colours</th>
             <th>bytes</th><th>of target</th>
           </tr></thead>
           <tbody id="logBody"></tbody>
@@ -1977,22 +2002,21 @@ GS.encodeOnce = async function (job, s, report, isCancelled) {
  * out of any theory.
  * ================================================================== */
 
-function relativise(w, sum, mode) {
-  // The script's weightSum is overwritten with the literal 2.00 one line
-  // after being computed. See the header comment: `half` is that, `sum`
-  // is the line it overwrote, `none` is the reading under which a weight
-  // of 1 means "use this knob's whole range".
-  var div = mode === 'sum' ? (sum > 0 ? sum : 1) : (mode === 'none' ? 1 : 2);
-  return t2(w / div);
+function relativise(w) {
+  // The script computes weightSum as the sum of the four weights and then
+  // overwrites it with the literal 2.00 on the next line. Both other
+  // readings of that were offered as options for a while and both
+  // measured worse — see TRIED AND REJECTED at the top of this file. So
+  // this is the divisor, and a weight of 1 closes half the gap.
+  return t2(w / 2);
 }
 
 GS.smash = async function (job, cfg, report, isCancelled) {
   var target = cfg.targetBytes;
-  var wsum = cfg.fWeight + cfg.lWeight + cfg.sWeight + cfg.cWeight;
-  var fW = relativise(cfg.fWeight, wsum, cfg.normMode);
-  var lW = relativise(cfg.lWeight, wsum, cfg.normMode);
-  var sW = relativise(cfg.sWeight, wsum, cfg.normMode);
-  var cW = relativise(cfg.cWeight, wsum, cfg.normMode);
+  var fW = relativise(cfg.fWeight);
+  var lW = relativise(cfg.lWeight);
+  var sW = relativise(cfg.sWeight);
+  var cW = relativise(cfg.cWeight);
 
   var initFramerate = t2(job.initFps);
   var initLossy = 0, initColors = 256;
@@ -2040,156 +2064,6 @@ GS.smash = async function (job, cfg, report, isCancelled) {
       colorMethod: cfg.colorMethod, resizeMethod: cfg.resizeMethod,
       optLevel: cfg.optLevel, crop: cfg.crop, motionThreshold: cfg.motionThreshold
     };
-  }
-
-  /* ---- SEARCH MODE ------------------------------------------------ *
-   *
-   * The two modes below this one are the script's, and both have the
-   * same flaw: they are open-loop guesses dressed as control. Approx is
-   * a proportional controller whose gain is the literal constant 2, and
-   * on a real clip it rings — 83% of target, then 116%, then 101%, then
-   * 84% — because it corrects from wherever it currently stands without
-   * ever learning how the file actually responded. Six encodes to land
-   * where three should.
-   *
-   * The fix is to stop steering four knobs and steer one. Every knob
-   * here is monotone in the same direction: less framerate, fewer
-   * colours, smaller, lossier all make the file smaller. So collapse
-   * them onto a single quality scalar q, where q=1 is every knob at its
-   * starting value and q=0 is every knob at its floor, and let the
-   * weights decide the *shape* of that descent rather than the size of
-   * each correction. Size is then monotone in q, and finding the q that
-   * hits the target is a one-dimensional root find — a solved problem
-   * with no magic constants in it.
-   *
-   * What the weights mean is unchanged in spirit and cleaner in fact:
-   * they are the mix, not the amount. Only their ratios matter now,
-   * because the search decides the amount. A weight of 0 still pins a
-   * knob exactly where it started.
-   *
-   * Size against q is close to a power law, so the step is a secant in
-   * log-log space: two probes give the exponent, and the third usually
-   * lands within a percent. A bracket is kept around the answer and the
-   * step falls back to bisection whenever the secant would leave it, so
-   * this cannot diverge and cannot oscillate — each probe strictly
-   * narrows the range. That is the whole difference: the modes below
-   * hope, this one converges.
-   * ---------------------------------------------------------------- */
-  if (cfg.mode === 'search') {
-    var wmax = Math.max(cfg.fWeight, cfg.lWeight, cfg.sWeight, cfg.cWeight);
-    if (wmax <= 0) wmax = 1;
-
-    /* The ladder. Framerate and lossiness move linearly because they are
-     * already linear-ish in what they cost; scale and colours move
-     * geometrically because 256 to 128 is the same step as 128 to 64,
-     * and treating them linearly spends the whole useful range in the
-     * first third of the travel. */
-    function ladder(q) {
-      var t = 1 - Math.max(0, Math.min(1, q));
-      function frac(w) { return Math.max(0, Math.min(1, t * (w / wmax))); }
-      var tf = frac(cfg.fWeight), tl = frac(cfg.lWeight),
-          ts = frac(cfg.sWeight), tc = frac(cfg.cWeight);
-      return {
-        fps: t2(initFramerate + (cfg.minFramerate - initFramerate) * tf),
-        lossy: Math.round(initLossy + (cfg.maxLossy - initLossy) * tl),
-        scale: t2(initScale * Math.pow(minScale / initScale, ts)),
-        colors: Math.max(cfg.minColors,
-                Math.round(initColors * Math.pow(cfg.minColors / initColors, tc)))
-      };
-    }
-
-    /* Root-finding on f(q) = log(size(q)) - log(target).
-     *
-     * Size follows q as a power law, so f is close to linear in log q.
-     * The step is a plain secant through the two probes nearest the
-     * target — which tracks the local exponent, where anchoring on a
-     * far endpoint tracks the average of the whole curve and crawls.
-     * A bracket is kept alongside purely as a guard: the secant is
-     * clamped into it, so the method keeps secant speed but cannot
-     * leave the region where the answer is known to be.
-     *
-     * Clamping rather than rejecting matters. The first version of this
-     * rejected any step landing near a bracket end and bisected
-     * instead, which threw away a secant estimate of 0.417 in favour of
-     * 0.698 — and 0.419 was the answer. */
-    var pts = [];                // every probe: {q, x, f}
-    var logT = Math.log(target);
-
-    async function probe(q, n) {
-      q = Math.max(0, Math.min(1, q));
-      var v = ladder(q);
-      var meta = { n: n, q: q, fps: v.fps, lossy: v.lossy, scale: v.scale, colors: v.colors };
-      report({ type: 'iterStart', meta: meta });
-      var r = await GS.encodeOnce(job, settings(v.fps, v.lossy, v.scale, v.colors), report, isCancelled);
-      meta.bytes = r.bytes.length;
-      log.push(meta);
-      consider(r, meta);
-      report({ type: 'iterDone', meta: meta });
-      pts.push({ q: q, x: Math.log(Math.max(q, 1e-4)), f: Math.log(r.bytes.length) - logT });
-      return r.bytes.length;
-    }
-
-    function bracket() {
-      var lo = null, hi = null;
-      for (var i = 0; i < pts.length; i++) {
-        var p = pts[i];
-        if (p.f <= 0) { if (!lo || p.q > lo.q) lo = p; }
-        else if (!hi || p.q < hi.q) hi = p;
-      }
-      return { lo: lo, hi: hi };
-    }
-    function closeEnough() {
-      return bestUnder && cfg.tolPct > 0 &&
-             best.res.bytes.length >= target * (1 - cfg.tolPct / 100);
-    }
-
-    var n = 1;
-    await probe(1, n++);
-
-    if (bracket().hi) {                       // q=1 overshoots; there is work to do
-      var s1 = pts[0];
-      // Power law of exponent 2.5 is roughly what the ladder does across
-      // its middle — close enough to put the second probe in the right
-      // neighbourhood, after which the secant takes over.
-      await probe(Math.max(0.02, Math.min(0.9, Math.exp(-s1.f / 2.5))), n++);
-
-      while (n <= cfg.maxIterations && !closeEnough()) {
-        if (isCancelled()) throw new Error('cancelled');
-        var br = bracket();
-        if (br.lo && br.hi && br.hi.q - br.lo.q < 0.004) break;
-
-        // Secant through the two probes closest to the target.
-        var near = pts.slice().sort(function (p, q2) { return Math.abs(p.f) - Math.abs(q2.f); });
-        var p1 = near[0], p2 = near[1];
-        var q;
-        if (p2 && Math.abs(p2.f - p1.f) > 1e-6) {
-          q = Math.exp(p1.x - p1.f * (p2.x - p1.x) / (p2.f - p1.f));
-        } else if (br.lo && br.hi) {
-          q = (br.lo.q + br.hi.q) / 2;
-        } else {
-          q = p1.q * (p1.f > 0 ? 0.45 : 1.6);   // no bracket yet: stride towards it
-        }
-        if (!isFinite(q) || q <= 0) break;
-
-        if (br.lo && br.hi) {                   // clamp into the bracket, never reject
-          var eps = Math.min(0.006, (br.hi.q - br.lo.q) * 0.05);
-          q = Math.max(br.lo.q + eps, Math.min(br.hi.q - eps, q));
-        }
-        q = Math.max(0, Math.min(1, q));
-        var seen = false;
-        for (var k = 0; k < pts.length; k++) if (Math.abs(pts[k].q - q) < 0.002) seen = true;
-        if (seen) {
-          // Repeating a probe learns nothing — but only stop if something
-          // already fits. With no bracket yet, a stalled secant means the
-          // curve is flatter than the model thinks, so stride down instead
-          // of returning an over-target result with budget still unspent.
-          if (br.lo) break;
-          q = Math.max(0, Math.min(q, br.hi ? br.hi.q * 0.5 : q * 0.5));
-          if (q < 0.005) { await probe(0, n++); break; }
-        }
-        await probe(q, n++);
-      }
-    }
   }
 
   /* ---- APPROXIMATION MODE ---------------------------------------- *
@@ -2809,7 +2683,6 @@ syncTargetText();
 
 var MODE_HINTS = {
   approx: 'The script\u2019s, and the default because it measurably wins. Overshoots and comes back; keep-best holds the good pass.',
-  search: 'One quality scalar, found by secant root-finding with a bracket. Tidier, slightly worse, but it always knows whether a target is reachable.',
   threshold: 'No feedback \u2014 each knob walks to its limit on a schedule and the run stops at the first encode that fits. Misses tight targets.'
 };
 Array.prototype.forEach.call($('modeSeg').children, function (b) {
@@ -3429,27 +3302,26 @@ function logRow(meta, done) {
   var tr = rowEls[key];
   if (!tr) {
     tr = document.createElement('tr');
-    for (var i = 0; i < 8; i++) tr.appendChild(document.createElement('td'));
+    for (var i = 0; i < 7; i++) tr.appendChild(document.createElement('td'));
     $('logBody').appendChild(tr);
     rowEls[key] = tr;
   }
   var td = tr.children;
   td[0].textContent = meta.pre ? meta.n + ' pre' : meta.n;
-  td[1].textContent = meta.q === undefined ? '—' : (+meta.q).toFixed(3);
-  td[2].textContent = (+meta.fps).toFixed(2);
-  td[3].textContent = meta.lossy;
-  td[4].textContent = (+meta.scale).toFixed(2);
-  td[5].textContent = meta.colors;
+  td[1].textContent = (+meta.fps).toFixed(2);
+  td[2].textContent = meta.lossy;
+  td[3].textContent = (+meta.scale).toFixed(2);
+  td[4].textContent = meta.colors;
   if (done) {
     tr.classList.remove('running');
-    td[6].textContent = fmtBytes(meta.bytes);
+    td[5].textContent = fmtBytes(meta.bytes);
     var pct = (meta.bytes / targetBytes()) * 100;
-    td[7].textContent = pct.toFixed(0) + '%';
-    td[7].className = meta.bytes <= targetBytes() ? 'hit' : 'miss';
+    td[6].textContent = pct.toFixed(0) + '%';
+    td[6].className = meta.bytes <= targetBytes() ? 'hit' : 'miss';
   } else {
     tr.classList.add('running');
-    td[6].textContent = '…';
-    td[7].textContent = '';
+    td[5].textContent = '…';
+    td[6].textContent = '';
   }
 }
 
@@ -3481,8 +3353,7 @@ function readCfg() {
     motionThreshold: parseInt($('motionThreshold').value, 10) || 0,
     maxOutEdge: Math.max(0, parseInt($('maxOutEdge').value, 10) || 0),
     keepBest: $('keepBest').checked,
-    tolPct: Math.max(0, parseFloat($('tolPct').value) || 0),
-    normMode: $('normMode').value
+    tolPct: Math.max(0, parseFloat($('tolPct').value) || 0)
   };
 }
 

--- a/gifsmash.html
+++ b/gifsmash.html
@@ -179,6 +179,9 @@
   .row.wide > label.name { flex-basis: 132px; }
   .grow { flex: 1 1 auto; min-width: 0; }
   .hint { color: #5f5f5f; font-size: .74rem; margin: -4px 0 12px 118px; }
+  /* the one line of prose left on the surface: what the profile just did */
+  .pick { color: #7d8a95; font-size: .76rem; margin: -2px 0 12px 118px; }
+  @media (max-width: 560px) { .pick { margin-left: 0; } }
   @media (max-width: 560px) { .hint { margin-left: 0; } .row > label.name, .row.wide > label.name { flex-basis: 100%; } }
   .hint.full { margin-left: 0; }
 
@@ -238,12 +241,102 @@
   details[open] > summary::before { content: "▾ "; }
   details .body { padding-top: 12px; }
 
-  /* ---- run bar ---- */
-  #runbar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-  #progWrap { flex: 1 1 140px; min-width: 120px; height: 5px; border-radius: 3px; background: #262626; overflow: hidden; }
-  #prog { height: 100%; width: 0%; background: var(--accent); transition: width .18s linear; }
+  /* ---- the smash button ----
+     It is the progress bar as well as the trigger: a run fills it left to
+     right, so the one thing you are looking at while you wait is the one
+     thing you pressed. --p carries the fraction. */
+  #runbar { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
   #status { font-size: .78rem; color: var(--muted); flex: 1 1 100%; min-height: 1.2em; }
   #status.err { color: var(--bad); }
+
+  #go {
+    --p: 0;
+    position: relative; isolation: isolate; overflow: hidden;
+    flex: 1 1 190px; min-width: 160px;
+    padding: 15px 26px;
+    font: 800 1.02rem/1 system-ui, -apple-system, sans-serif;
+    letter-spacing: .13em; text-transform: uppercase;
+    color: #eef6ff;
+    border: 0; border-radius: 11px;
+    background: linear-gradient(180deg, #2a6ba8, #17456f);
+    cursor: pointer;
+    box-shadow: 0 3px 0 #0e2740, 0 10px 26px -12px rgba(80,164,240,.9),
+                inset 0 1px 0 rgba(255,255,255,.22);
+    transition: transform .13s cubic-bezier(.34,1.6,.5,1), box-shadow .2s, filter .2s;
+  }
+  #go .lbl { position: relative; z-index: 2; display: block; }
+  /* the fill */
+  #go::before {
+    content: ""; position: absolute; inset: 0; z-index: 0;
+    background: linear-gradient(90deg, #3f95dd, #6fc0f5);
+    transform: scaleX(var(--p)); transform-origin: left;
+    transition: transform .25s cubic-bezier(.4,0,.2,1);
+  }
+  /* the sheen that sweeps across while it waits to be pressed */
+  #go::after {
+    content: ""; position: absolute; top: -60%; bottom: -60%; left: 0; width: 45%;
+    z-index: 1; pointer-events: none;
+    background: linear-gradient(100deg, transparent, rgba(255,255,255,.30), transparent);
+    transform: translateX(-160%) skewX(-16deg);
+    animation: sheen 4.2s cubic-bezier(.5,0,.5,1) infinite;
+  }
+  #go .ring {
+    position: absolute; z-index: 1; left: 50%; top: 50%; width: 12px; height: 12px;
+    margin: -6px 0 0 -6px; border-radius: 50%; pointer-events: none;
+    border: 2px solid rgba(190,225,255,.95); opacity: 0; transform: scale(1);
+  }
+  #go.blast .ring { animation: blast .55s cubic-bezier(.2,.7,.3,1); }
+  #go:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 5px 0 #0e2740, 0 18px 34px -14px rgba(110,192,245,1),
+                inset 0 1px 0 rgba(255,255,255,.3);
+    filter: saturate(1.15);
+  }
+  #go:active:not(:disabled) {
+    transform: translateY(2px);
+    box-shadow: 0 1px 0 #0e2740, 0 6px 16px -10px rgba(110,192,245,.9),
+                inset 0 1px 0 rgba(255,255,255,.18);
+  }
+  #go:disabled { opacity: .38; filter: grayscale(.55); cursor: default; box-shadow: 0 3px 0 #0e2740; }
+  #go:disabled::after { animation: none; }
+  /* A run disables the button so it cannot be pressed twice, but the greyed
+     -out treatment is for "there is nothing to smash yet" and it was
+     swallowing the whole running state. Keep the disabling, drop the pallor. */
+  #go.running:disabled { opacity: 1; filter: none; cursor: progress; }
+  #go.running:disabled::after { animation: sheen 1.15s cubic-bezier(.5,0,.5,1) infinite; }
+  #go.running { animation: throb 1.5s ease-in-out infinite; }
+  #go.running::after { animation-duration: 1.15s; }
+  /* a kick each time an iteration lands, so the wait has a pulse to it */
+  #go.hit { animation: hit .34s cubic-bezier(.25,1.7,.4,1); }
+  #go.done { animation: done .6s ease-out; }
+  #go.done::before { background: linear-gradient(90deg, #3f9e63, #6fd08c); }
+
+  @keyframes sheen {
+    0%, 62% { transform: translateX(-160%) skewX(-16deg); }
+    100%    { transform: translateX(430%)  skewX(-16deg); }
+  }
+  @keyframes throb {
+    0%, 100% { box-shadow: 0 3px 0 #0e2740, 0 10px 26px -12px rgba(80,164,240,.8), inset 0 1px 0 rgba(255,255,255,.22); }
+    50%      { box-shadow: 0 3px 0 #0e2740, 0 14px 40px -10px rgba(120,200,255,1),  inset 0 1px 0 rgba(255,255,255,.3); }
+  }
+  @keyframes hit {
+    0%   { transform: scale(1); }
+    38%  { transform: scale(1.045) translateY(-1px); }
+    100% { transform: scale(1); }
+  }
+  @keyframes done {
+    0%   { transform: scale(1); filter: brightness(1); }
+    22%  { transform: scale(1.06); filter: brightness(1.5); }
+    100% { transform: scale(1); filter: brightness(1); }
+  }
+  @keyframes blast {
+    0%   { opacity: .9; transform: scale(1); border-width: 3px; }
+    100% { opacity: 0; transform: scale(34); border-width: 1px; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    #go, #go::after, #go .ring { animation: none !important; transition: none; }
+    #go::before { transition: none; }
+  }
 
   /* ---- cropper ---- */
   #cropStage {
@@ -420,12 +513,17 @@
         <span id="cropSize">—</span>
         <button type="button" id="cropReset" disabled>Whole frame</button>
       </div>
-      <div class="cropbar">
-        <label for="cropX">x</label><input type="number" id="cropX" value="0" min="0" step="1" disabled />
-        <label for="cropY">y</label><input type="number" id="cropY" value="0" min="0" step="1" disabled />
-        <label for="cropW">w</label><input type="number" id="cropW" value="0" min="1" step="1" disabled />
-        <label for="cropH">h</label><input type="number" id="cropH" value="0" min="1" step="1" disabled />
-      </div>
+      <details>
+        <summary>Exact numbers</summary>
+        <div class="body">
+          <div class="cropbar" style="margin-top:0">
+            <label for="cropX">x</label><input type="number" id="cropX" value="0" min="0" step="1" disabled />
+            <label for="cropY">y</label><input type="number" id="cropY" value="0" min="0" step="1" disabled />
+            <label for="cropW">w</label><input type="number" id="cropW" value="0" min="1" step="1" disabled />
+            <label for="cropH">h</label><input type="number" id="cropH" value="0" min="1" step="1" disabled />
+          </div>
+        </div>
+      </details>
     </div>
 
     <div class="panel">
@@ -468,7 +566,7 @@
           <option value="web">Web page — inline</option>
         </select>
       </div>
-      <p class="hint" id="profileHint">Nothing preset — the controls below are yours.</p>
+      <p class="pick" id="profileHint">Nothing preset — the controls below are yours.</p>
       <div class="row">
         <label class="name" for="targetVal">Size</label>
         <input type="number" id="targetVal" value="2" min="0.001" step="0.1" />
@@ -478,25 +576,76 @@
         </select>
         <span class="hint full" style="margin:0" id="targetBytesTxt">= 2,000,000 bytes</span>
       </div>
-      <div class="row">
-        <label class="name" for="maxOutEdge">Max output</label>
-        <input type="number" id="maxOutEdge" value="0" min="0" max="4096" step="16" />
-        <span class="hint full" style="margin:0">px on the long edge — 0 for no cap</span>
-      </div>
-      <div class="row">
-        <label class="name">Mode</label>
-        <div class="seg" id="modeSeg">
-          <button type="button" data-mode="approx" class="on">Approximate</button>
-          <button type="button" data-mode="threshold">Threshold</button>
+      <details>
+        <summary>How it searches</summary>
+        <div class="body">
+          <div class="row">
+            <label class="name" for="maxOutEdge">Max output</label>
+            <input type="number" id="maxOutEdge" value="0" min="0" max="4096" step="16" />
+            <span class="hint full" style="margin:0">px on the long edge — 0 for no cap</span>
+          </div>
+          <div class="row">
+            <label class="name">Mode</label>
+            <div class="seg" id="modeSeg">
+              <button type="button" data-mode="approx" class="on">Approximate</button>
+              <button type="button" data-mode="search">Search</button>
+              <button type="button" data-mode="threshold">Threshold</button>
+            </div>
+          </div>
+          <p class="hint full" id="modeHint">Feeds each result back in: overshoot by 2× and the
+            next iteration cuts twice as hard. Lands close to the target from either side.</p>
+          <div class="info" id="i-loop" hidden>
+            <p><b>Approximate</b> is the script's, and the default because it measurably wins.
+               It corrects each knob by its own function of one ratio, overshoots, and comes
+               back — which looks untidy in the log and does not matter, because keep-best
+               holds the good pass. Across ten source-and-target combinations it fitted 10/10
+               in 4.3 encodes, landing at 83% of the target on average.</p>
+            <p><b>Search</b> collapses the four knobs onto a single quality scalar and finds
+               the target by secant root-finding, with a bracket so it cannot diverge. It is
+               the tidier algorithm and it lost: 10/10 fits, 4.6 encodes, 77% utilisation. GIF
+               size against quality is not smooth enough for a root finder — colours and
+               lossiness move in integer steps and the palette is rebuilt from scratch each
+               time — and approximate's untidy exploring copes with that better than
+               convergence does. Kept because it always brackets, so it can tell you a target
+               is impossible rather than just failing to reach it.</p>
+            <p><b>Threshold</b> is the script's other mode and the weak one: no feedback at
+               all, every knob walking to its limit on a fixed schedule. It missed 4 of those
+               10 targets outright while spending 9.1 encodes doing it. Use it when you want
+               a predictable ramp rather than a result.</p>
+            <p><b>Keep best</b> holds whichever pass landed closest under the target rather
+               than whichever ran last. The script always shipped the last one, so a pass that
+               overshot after a good one threw the good one away. Turn it off to reproduce
+               that. <b>Stop within</b> ends the run once a result is under target and within
+               this much of it; 0 spends every iteration. A run also stops early when a result
+               fits with every knob still at its starting value — there is nothing left to
+               hand back.</p>
+            <p><b>Weights</b> were divided by 2 by the script no matter what the others were,
+               so weight 1 closes half the gap. Sharing divides by the sum of the four, which
+               is what the line it overwrote computed. As-given divides by nothing. In search
+               mode only the ratios matter — the weights are the mix, and the search decides
+               the amount.</p>
+          </div>
+          <div class="row">
+            <label class="name" for="maxIter">Iterations</label>
+            <input type="number" id="maxIter" value="6" min="1" max="24" step="1" />
+            <span class="hint full" style="margin:0">upper bound on encodes</span>
+          </div>
+          <div class="row wide"><label class="name">Keep</label>
+            <label class="check"><input type="checkbox" id="keepBest" checked /> best iteration, not the last</label>
+          </div>
+          <div class="row wide"><label class="name" for="tolPct">Stop within</label>
+            <input type="number" id="tolPct" value="2" min="0" max="50" step="0.5" />
+            <span class="hint full" style="margin:0">% under target — 0 runs every iteration</span>
+          </div>
+          <div class="row wide"><label class="name" for="normMode">Weights are</label>
+            <select id="normMode" class="grow">
+              <option value="half" selected>halved — as the script shipped</option>
+              <option value="sum">shared across the four</option>
+              <option value="none">used as given</option>
+            </select>
+          </div>
         </div>
-      </div>
-      <p class="hint" id="modeHint">Feeds each result back in: overshoot by 2× and the next
-        iteration cuts twice as hard. Lands close to the target from either side.</p>
-      <div class="row">
-        <label class="name" for="maxIter">Iterations</label>
-        <input type="number" id="maxIter" value="6" min="1" max="24" step="1" />
-        <span class="hint full" style="margin:0">upper bound on encodes</span>
-      </div>
+      </details>
     </div>
 
     <div class="panel">
@@ -531,8 +680,6 @@
             <input type="range" id="fWeight" min="0" max="2" step="0.05" value="1" />
             <output id="fWeightOut">1.00</output>
           </div>
-          <div class="lim"><label for="minFramerate">floor</label>
-            <input type="number" id="minFramerate" value="0.5" min="0.1" max="60" step="0.1" /> fps</div>
         </div>
         <div class="knob" id="knobL">
           <h3>Lossiness <em id="lCur">—</em></h3>
@@ -540,8 +687,6 @@
             <input type="range" id="lWeight" min="0" max="2" step="0.05" value="1" />
             <output id="lWeightOut">1.00</output>
           </div>
-          <div class="lim"><label for="maxLossy">ceiling</label>
-            <input type="number" id="maxLossy" value="200" min="0" max="400" step="5" /></div>
         </div>
         <div class="knob" id="knobS">
           <h3>Scale <em id="sCur">—</em></h3>
@@ -549,8 +694,6 @@
             <input type="range" id="sWeight" min="0" max="2" step="0.05" value="1" />
             <output id="sWeightOut">1.00</output>
           </div>
-          <div class="lim"><label for="minScale">floor</label>
-            <input type="number" id="minScale" value="0.1" min="0.02" max="1" step="0.05" /> ×</div>
         </div>
         <div class="knob" id="knobC">
           <h3>Colours <em id="cCur">—</em></h3>
@@ -558,10 +701,26 @@
             <input type="range" id="cWeight" min="0" max="2" step="0.05" value="1" />
             <output id="cWeightOut">1.00</output>
           </div>
-          <div class="lim"><label for="minColors">floor</label>
-            <input type="number" id="minColors" value="4" min="2" max="256" step="1" /></div>
         </div>
       </div>
+
+      <details>
+        <summary>Limits <span style="text-transform:none;letter-spacing:0;color:#5c5c5c">— how far each one may go</span></summary>
+        <div class="body">
+          <div class="row"><label class="name" for="minFramerate">Framerate floor</label>
+            <input type="number" id="minFramerate" value="0.5" min="0.1" max="60" step="0.1" />
+            <span class="hint full" style="margin:0">fps</span></div>
+          <div class="row"><label class="name" for="maxLossy">Lossiness ceiling</label>
+            <input type="number" id="maxLossy" value="200" min="0" max="400" step="5" />
+            <span class="hint full" style="margin:0">0–200 is gifsicle's range</span></div>
+          <div class="row"><label class="name" for="minScale">Scale floor</label>
+            <input type="number" id="minScale" value="0.1" min="0.02" max="1" step="0.05" />
+            <span class="hint full" style="margin:0">× of the crop</span></div>
+          <div class="row"><label class="name" for="minColors">Colour floor</label>
+            <input type="number" id="minColors" value="4" min="2" max="256" step="1" />
+            <span class="hint full" style="margin:0">fewest palette entries</span></div>
+        </div>
+      </details>
 
       <div class="row wide" style="margin-top:12px">
         <label class="name" for="motionThreshold">Motion threshold</label>
@@ -681,45 +840,6 @@
         </div>
       </details>
 
-      <details>
-        <summary>Loop behaviour <button type="button" class="i" data-info="i-loop" aria-expanded="false" aria-label="About loop behaviour">i</button></summary>
-        <div class="body">
-          <div class="row wide"><label class="name">Keep</label>
-            <label class="check"><input type="checkbox" id="keepBest" checked /> best iteration, not the last</label>
-          </div>
-          <div class="row wide"><label class="name" for="tolPct">Stop within</label>
-            <input type="number" id="tolPct" value="2" min="0" max="50" step="0.5" />
-            <span class="hint full" style="margin:0">% under target — 0 runs every iteration</span>
-          </div>
-          <div class="row wide"><label class="name" for="normMode">Weights are</label>
-            <select id="normMode" class="grow">
-              <option value="half" selected>halved — as the script shipped</option>
-              <option value="sum">shared across the four</option>
-              <option value="none">used as given</option>
-            </select>
-          </div>
-          <div class="info" id="i-loop" hidden>
-            <p><b>Keep best</b> holds on to whichever pass landed closest under the target
-               rather than whichever happened to run last. The original script always shipped
-               the last one, which meant an iteration that overshot after a good one threw the
-               good one away. Turn it off to reproduce that.</p>
-            <p><b>Stop within</b> ends the run once a result is under the target and within
-               this much of it. Set it to 0 and the run always spends every iteration, which
-               is what the script did — and, with keep-best on, occasionally finds something
-               better on the last pass.</p>
-            <p>A run also stops early when a result fits and every knob is still at its
-               starting value: there is nothing left to hand back, so further passes would
-               encode the same file again.</p>
-          </div>
-          <p class="hint">The script divided every weight by 2 no matter what the others were, so
-             weight 1 means "close half the gap". Sharing divides by the sum of the four instead,
-             which is what the line it overwrote was computing. As-given divides by nothing: in
-             threshold mode that is the setting where weight 1 walks a knob all the way to its
-             limit by the last iteration. In approximate mode it applies the whole correction at
-             once, which overshoots and then swings back — useful for finding the floor fast,
-             not for landing on a number.</p>
-        </div>
-      </details>
     </div>
 
     <div class="panel">
@@ -734,9 +854,11 @@
            instead, and the status line says so.</p>
       </div>
       <div id="runbar">
-        <button id="go" class="primary" disabled>Smash</button>
+        <button id="go" disabled aria-label="Smash">
+          <span class="ring" aria-hidden="true"></span>
+          <span class="lbl">Smash</span>
+        </button>
         <button id="stop" class="danger" disabled>Stop</button>
-        <div id="progWrap"><div id="prog"></div></div>
         <div id="status">Load a video or GIF to begin.</div>
       </div>
     </div>
@@ -814,7 +936,7 @@
         <div class="empty" id="logEmpty">Each pass prints the settings it tried and what they weighed.</div>
         <table class="log" id="logTable" style="display:none">
           <thead><tr>
-            <th>#</th><th>fps</th><th>lossy</th><th>scale</th><th>colours</th>
+            <th>#</th><th>q</th><th>fps</th><th>lossy</th><th>scale</th><th>colours</th>
             <th>bytes</th><th>of target</th>
           </tr></thead>
           <tbody id="logBody"></tbody>
@@ -1920,6 +2042,156 @@ GS.smash = async function (job, cfg, report, isCancelled) {
     };
   }
 
+  /* ---- SEARCH MODE ------------------------------------------------ *
+   *
+   * The two modes below this one are the script's, and both have the
+   * same flaw: they are open-loop guesses dressed as control. Approx is
+   * a proportional controller whose gain is the literal constant 2, and
+   * on a real clip it rings — 83% of target, then 116%, then 101%, then
+   * 84% — because it corrects from wherever it currently stands without
+   * ever learning how the file actually responded. Six encodes to land
+   * where three should.
+   *
+   * The fix is to stop steering four knobs and steer one. Every knob
+   * here is monotone in the same direction: less framerate, fewer
+   * colours, smaller, lossier all make the file smaller. So collapse
+   * them onto a single quality scalar q, where q=1 is every knob at its
+   * starting value and q=0 is every knob at its floor, and let the
+   * weights decide the *shape* of that descent rather than the size of
+   * each correction. Size is then monotone in q, and finding the q that
+   * hits the target is a one-dimensional root find — a solved problem
+   * with no magic constants in it.
+   *
+   * What the weights mean is unchanged in spirit and cleaner in fact:
+   * they are the mix, not the amount. Only their ratios matter now,
+   * because the search decides the amount. A weight of 0 still pins a
+   * knob exactly where it started.
+   *
+   * Size against q is close to a power law, so the step is a secant in
+   * log-log space: two probes give the exponent, and the third usually
+   * lands within a percent. A bracket is kept around the answer and the
+   * step falls back to bisection whenever the secant would leave it, so
+   * this cannot diverge and cannot oscillate — each probe strictly
+   * narrows the range. That is the whole difference: the modes below
+   * hope, this one converges.
+   * ---------------------------------------------------------------- */
+  if (cfg.mode === 'search') {
+    var wmax = Math.max(cfg.fWeight, cfg.lWeight, cfg.sWeight, cfg.cWeight);
+    if (wmax <= 0) wmax = 1;
+
+    /* The ladder. Framerate and lossiness move linearly because they are
+     * already linear-ish in what they cost; scale and colours move
+     * geometrically because 256 to 128 is the same step as 128 to 64,
+     * and treating them linearly spends the whole useful range in the
+     * first third of the travel. */
+    function ladder(q) {
+      var t = 1 - Math.max(0, Math.min(1, q));
+      function frac(w) { return Math.max(0, Math.min(1, t * (w / wmax))); }
+      var tf = frac(cfg.fWeight), tl = frac(cfg.lWeight),
+          ts = frac(cfg.sWeight), tc = frac(cfg.cWeight);
+      return {
+        fps: t2(initFramerate + (cfg.minFramerate - initFramerate) * tf),
+        lossy: Math.round(initLossy + (cfg.maxLossy - initLossy) * tl),
+        scale: t2(initScale * Math.pow(minScale / initScale, ts)),
+        colors: Math.max(cfg.minColors,
+                Math.round(initColors * Math.pow(cfg.minColors / initColors, tc)))
+      };
+    }
+
+    /* Root-finding on f(q) = log(size(q)) - log(target).
+     *
+     * Size follows q as a power law, so f is close to linear in log q.
+     * The step is a plain secant through the two probes nearest the
+     * target — which tracks the local exponent, where anchoring on a
+     * far endpoint tracks the average of the whole curve and crawls.
+     * A bracket is kept alongside purely as a guard: the secant is
+     * clamped into it, so the method keeps secant speed but cannot
+     * leave the region where the answer is known to be.
+     *
+     * Clamping rather than rejecting matters. The first version of this
+     * rejected any step landing near a bracket end and bisected
+     * instead, which threw away a secant estimate of 0.417 in favour of
+     * 0.698 — and 0.419 was the answer. */
+    var pts = [];                // every probe: {q, x, f}
+    var logT = Math.log(target);
+
+    async function probe(q, n) {
+      q = Math.max(0, Math.min(1, q));
+      var v = ladder(q);
+      var meta = { n: n, q: q, fps: v.fps, lossy: v.lossy, scale: v.scale, colors: v.colors };
+      report({ type: 'iterStart', meta: meta });
+      var r = await GS.encodeOnce(job, settings(v.fps, v.lossy, v.scale, v.colors), report, isCancelled);
+      meta.bytes = r.bytes.length;
+      log.push(meta);
+      consider(r, meta);
+      report({ type: 'iterDone', meta: meta });
+      pts.push({ q: q, x: Math.log(Math.max(q, 1e-4)), f: Math.log(r.bytes.length) - logT });
+      return r.bytes.length;
+    }
+
+    function bracket() {
+      var lo = null, hi = null;
+      for (var i = 0; i < pts.length; i++) {
+        var p = pts[i];
+        if (p.f <= 0) { if (!lo || p.q > lo.q) lo = p; }
+        else if (!hi || p.q < hi.q) hi = p;
+      }
+      return { lo: lo, hi: hi };
+    }
+    function closeEnough() {
+      return bestUnder && cfg.tolPct > 0 &&
+             best.res.bytes.length >= target * (1 - cfg.tolPct / 100);
+    }
+
+    var n = 1;
+    await probe(1, n++);
+
+    if (bracket().hi) {                       // q=1 overshoots; there is work to do
+      var s1 = pts[0];
+      // Power law of exponent 2.5 is roughly what the ladder does across
+      // its middle — close enough to put the second probe in the right
+      // neighbourhood, after which the secant takes over.
+      await probe(Math.max(0.02, Math.min(0.9, Math.exp(-s1.f / 2.5))), n++);
+
+      while (n <= cfg.maxIterations && !closeEnough()) {
+        if (isCancelled()) throw new Error('cancelled');
+        var br = bracket();
+        if (br.lo && br.hi && br.hi.q - br.lo.q < 0.004) break;
+
+        // Secant through the two probes closest to the target.
+        var near = pts.slice().sort(function (p, q2) { return Math.abs(p.f) - Math.abs(q2.f); });
+        var p1 = near[0], p2 = near[1];
+        var q;
+        if (p2 && Math.abs(p2.f - p1.f) > 1e-6) {
+          q = Math.exp(p1.x - p1.f * (p2.x - p1.x) / (p2.f - p1.f));
+        } else if (br.lo && br.hi) {
+          q = (br.lo.q + br.hi.q) / 2;
+        } else {
+          q = p1.q * (p1.f > 0 ? 0.45 : 1.6);   // no bracket yet: stride towards it
+        }
+        if (!isFinite(q) || q <= 0) break;
+
+        if (br.lo && br.hi) {                   // clamp into the bracket, never reject
+          var eps = Math.min(0.006, (br.hi.q - br.lo.q) * 0.05);
+          q = Math.max(br.lo.q + eps, Math.min(br.hi.q - eps, q));
+        }
+        q = Math.max(0, Math.min(1, q));
+        var seen = false;
+        for (var k = 0; k < pts.length; k++) if (Math.abs(pts[k].q - q) < 0.002) seen = true;
+        if (seen) {
+          // Repeating a probe learns nothing — but only stop if something
+          // already fits. With no bracket yet, a stalled secant means the
+          // curve is flatter than the model thinks, so stride down instead
+          // of returning an over-target result with budget still unspent.
+          if (br.lo) break;
+          q = Math.max(0, Math.min(q, br.hi ? br.hi.q * 0.5 : q * 0.5));
+          if (q < 0.005) { await probe(0, n++); break; }
+        }
+        await probe(q, n++);
+      }
+    }
+  }
+
   /* ---- APPROXIMATION MODE ---------------------------------------- *
    * Each result is fed back as globalWeight = target / actual, and each
    * knob moves by its own function of that ratio. A file twice too big
@@ -2414,7 +2686,19 @@ function setStatus(msg, isErr) {
   el.textContent = msg;
   el.className = isErr ? 'err' : '';
 }
-function setProgress(f) { $('prog').style.width = Math.round(Math.max(0, Math.min(1, f)) * 100) + '%'; }
+function setProgress(f) {
+  $('go').style.setProperty('--p', Math.max(0, Math.min(1, f)).toFixed(4));
+}
+function buttonLabel(t) { $('go').querySelector('.lbl').textContent = t; }
+/* Restart a CSS animation by taking the class off and forcing a reflow —
+ * re-adding it without that is a no-op if the animation is still running. */
+function flash(cls, ms) {
+  var el = $('go');
+  el.classList.remove(cls);
+  void el.offsetWidth;
+  el.classList.add(cls);
+  setTimeout(function () { el.classList.remove(cls); }, ms);
+}
 
 function targetBytes() {
   var v = parseFloat($('targetVal').value) || 0;
@@ -2524,8 +2808,9 @@ $('targetUnit').addEventListener('change', syncTargetText);
 syncTargetText();
 
 var MODE_HINTS = {
-  approx: 'Feeds each result back in: overshoot by 2× and the next iteration cuts twice as hard. Lands close to the target from either side.',
-  threshold: 'No feedback — each knob walks steadily towards its limit and the run stops at the first encode that fits. Predictable, and usually smaller than it needed to be.'
+  approx: 'The script\u2019s, and the default because it measurably wins. Overshoots and comes back; keep-best holds the good pass.',
+  search: 'One quality scalar, found by secant root-finding with a bracket. Tidier, slightly worse, but it always knows whether a target is reachable.',
+  threshold: 'No feedback \u2014 each knob walks to its limit on a schedule and the run stops at the first encode that fits. Misses tight targets.'
 };
 Array.prototype.forEach.call($('modeSeg').children, function (b) {
   b.addEventListener('click', function () {
@@ -2981,6 +3266,9 @@ async function load(file) {
   srcEl = null;
   crop = null;
   cropImg = null;
+  $('go').classList.remove('running', 'done');
+  buttonLabel('Smash');
+  setProgress(0);
   releaseProxy();
   setupCropper();
   showView('out');
@@ -3141,26 +3429,27 @@ function logRow(meta, done) {
   var tr = rowEls[key];
   if (!tr) {
     tr = document.createElement('tr');
-    for (var i = 0; i < 7; i++) tr.appendChild(document.createElement('td'));
+    for (var i = 0; i < 8; i++) tr.appendChild(document.createElement('td'));
     $('logBody').appendChild(tr);
     rowEls[key] = tr;
   }
   var td = tr.children;
   td[0].textContent = meta.pre ? meta.n + ' pre' : meta.n;
-  td[1].textContent = (+meta.fps).toFixed(2);
-  td[2].textContent = meta.lossy;
-  td[3].textContent = (+meta.scale).toFixed(2);
-  td[4].textContent = meta.colors;
+  td[1].textContent = meta.q === undefined ? '—' : (+meta.q).toFixed(3);
+  td[2].textContent = (+meta.fps).toFixed(2);
+  td[3].textContent = meta.lossy;
+  td[4].textContent = (+meta.scale).toFixed(2);
+  td[5].textContent = meta.colors;
   if (done) {
     tr.classList.remove('running');
-    td[5].textContent = fmtBytes(meta.bytes);
+    td[6].textContent = fmtBytes(meta.bytes);
     var pct = (meta.bytes / targetBytes()) * 100;
-    td[6].textContent = pct.toFixed(0) + '%';
-    td[6].className = meta.bytes <= targetBytes() ? 'hit' : 'miss';
+    td[7].textContent = pct.toFixed(0) + '%';
+    td[7].className = meta.bytes <= targetBytes() ? 'hit' : 'miss';
   } else {
     tr.classList.add('running');
-    td[5].textContent = '…';
-    td[6].textContent = '';
+    td[6].textContent = '…';
+    td[7].textContent = '';
   }
 }
 
@@ -3201,6 +3490,10 @@ $('go').addEventListener('click', function () {
   if (!job || running) return;
   running = true;
   $('go').disabled = true;
+  $('go').classList.remove('done');
+  $('go').classList.add('running');
+  flash('blast', 600);
+  buttonLabel('Smashing');
   $('stop').disabled = false;
   $('download').disabled = true;
   clearLog();
@@ -3239,13 +3532,17 @@ function onMessage(m) {
     setStatus('Iteration ' + m.meta.n + (m.meta.pre ? ' (quality pre-pass)' : '') + '…');
     return;
   }
-  if (m.type === 'iterDone') { logRow(m.meta, true); return; }
+  if (m.type === 'iterDone') { logRow(m.meta, true); flash('hit', 400); return; }
 
   if (m.type === 'done') {
     running = false;
     $('go').disabled = false;
+    $('go').classList.remove('running');
     $('stop').disabled = true;
     setProgress(1);
+    buttonLabel('Smash again');
+    flash('done', 900);
+    setTimeout(function () { if (!running) setProgress(0); }, 1000);
 
     var blob = new Blob([m.bytes], { type: 'image/gif' });
     if (outUrl) URL.revokeObjectURL(outUrl);
@@ -3292,6 +3589,8 @@ function onMessage(m) {
   if (m.type === 'cancelled') {
     running = false;
     $('go').disabled = false;
+    $('go').classList.remove('running');
+    buttonLabel('Smash');
     $('stop').disabled = true;
     setProgress(0);
     setStatus('Stopped.');
@@ -3301,6 +3600,8 @@ function onMessage(m) {
   if (m.type === 'error') {
     running = false;
     $('go').disabled = false;
+    $('go').classList.remove('running');
+    buttonLabel('Smash');
     $('stop').disabled = true;
     setProgress(0);
     setStatus(m.message || 'Something went wrong.', true);


### PR DESCRIPTION
Net **−129 lines**. Two things were built, measured, and removed; what survives is a smaller page and a better button.

## Measured and deleted

**Search mode.** I argued approximate was the weak part — a proportional controller with a gain of literally 2, ringing rather than converging (83% of target, then 116%, then 101%, then 84%) — and replaced it with a bracketed secant over a single quality scalar, weights becoming the shape of the descent rather than the size of each correction.

| mode | fits | avg encodes | avg utilisation |
|---|---|---|---|
| approximate | 10/10 | 4.3 | **82.7%** |
| search | 10/10 | 4.6 | 77.4% |

Tidier algorithm, worse tool, every time. The reason: **GIF size against quality is a staircase, not a curve** — colours and lossiness move in integer steps and the palette is rebuilt from scratch at each one, so the smooth local behaviour a secant method assumes is not there. Approximate's overshooting samples that staircase in several places and keep-best takes the good sample, which is why the ringing that looks like the flaw is doing the work. Its one surviving claim — that it always holds a bracket and so can call a target impossible — is not worth a third mode when approximate already reports that it failed.

**The weight-normalisation control.** The script computes `weightSum` as the sum of the four weights and overwrites it with the literal `2.00` a line later; I shipped all three readings as a select. Over thirty runs:

| approx, weights | fits | utilisation |
|---|---|---|
| halved (the accident) | 10/10 | **82.7%** |
| shared across the four | 3/10 | 53.4% |
| used as given | 10/10 | 33.2% |

Shared cannot hit a target. As-given only "fits" by overshooting so far down that two thirds of the budget is thrown away. The accident beats both things it might have been, so the divisor is 2, the control is gone, and the explanation shrank to one sentence.

Both results are written into the file's header comment under `TRIED AND REJECTED`, per the repo's habit of recording what was tried and rejected — so the next person to have the same good idea finds the numbers before rebuilding it.

Also removed: the `q` column that only search ever populated, and a dead `button.primary` rule orphaned when the button was rebuilt.

## A quieter page

Everything that is not a decision moved behind a dropdown — the crop's exact numbers, mode and iteration controls, the four floors, all of loop behaviour. What is left on the surface: a drop zone, a picture to crop, a profile, a size, four weight sliders, the motion threshold, and the button. The prose that used to sit between controls now lives inside the panels the `i` buttons open, where it can be as long as it needs to be.

## A button

It is the progress bar as well as the trigger, so the thing you watch while you wait is the thing you pressed. A fill that advances with the run, a sheen that sweeps, a shockwave on the press, a kick each time an iteration lands, and a green flash when it fits that drains back to idle a second later. Honours `prefers-reduced-motion`.

## Still open

**Threshold mode fits 6 of 10 targets in 9.1 encodes** — worse than approximate on every axis. It survives only because it is what the script did, and the fidelity of the port was the brief. Say the word and it goes too.

## Verification

- Encoder sweep after the removals: 576 setting combinations, 0 producing stray transparency or collapsed frame counts.
- Both remaining modes run to completion over HTTP and `file://`, with crop, motion threshold and profiles applied.
- No horizontal overflow at 390px, collapsed or with every dropdown and info panel open.
- Framing playback from #33 still animates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zMbyiX52mCStppuzLAB7m