### PR TITLE
Three of the four Cythera links have been 404 since the tools moved out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,12 @@ The Cythera and retro-Mac tools used to live here in `cythera/`. They are their
 own repository now — <https://github.com/e-z-g/cythera> — served at the same
 URLs, `e-z-g.github.io/cythera/…`, because a project repo of that name occupies
 that path. `index.html` and `README.md` still link to them and should keep
-doing so; the links did not change.
+doing so — but **the filenames on the other side do change, and nothing here
+notices**. Three of the four links were 404 for a while: the viewer is
+`explorer.html` now, not `cythera_data_viewer.html`; the paint tool is
+`canvas.html`, not `colorcyclecanvas.html`; and the Mac Resource Fork Browser
+was retired outright, its decoders folded into the viewer's Resource Fork
+gallery. Check them against that repository when it moves.
 
 ```
 index.html            tool directory (the site's front page)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Web tools and interactive experiments: <https://e-z-g.github.io/>
 
 | | |
 |---|---|
-| [Cythera Data Viewer](https://e-z-g.github.io/cythera/cythera_data_viewer.html) | [Cythera Mobile](https://e-z-g.github.io/cythera/mobile.html) |
-| [ColorCycleCanvas](https://e-z-g.github.io/cythera/colorcyclecanvas.html) | [Mac Resource Fork Browser](https://e-z-g.github.io/cythera/resource_fork_browser.html) |
+| [Cythera Data Viewer](https://e-z-g.github.io/cythera/explorer.html) | [Cythera Mobile](https://e-z-g.github.io/cythera/mobile.html) |
+| [ColorCycleCanvas](https://e-z-g.github.io/cythera/canvas.html) | |
 | [JumpStart 4th Grade Player](https://e-z-g.github.io/infj4.html) | |
 
 ## Local preview

--- a/index.html
+++ b/index.html
@@ -113,10 +113,9 @@
   <section>
     <h2>Retro Mac / Cythera</h2>
     <div class="grid">
-      <a href="cythera/cythera_data_viewer.html">Cythera Data Viewer</a>
+      <a href="cythera/explorer.html">Cythera Data Viewer</a>
       <a href="cythera/mobile.html">Cythera Mobile</a>
-      <a href="cythera/colorcyclecanvas.html">ColorCycleCanvas</a>
-      <a href="cythera/resource_fork_browser.html">Mac Resource Fork Browser</a>
+      <a href="cythera/canvas.html">ColorCycleCanvas</a>
       <a href="infj4.html">JumpStart 4th Grade Player</a>
     </div>
   </section>


### PR DESCRIPTION
Checked against the live site just now:

| link on the front page | today |
|---|---|
| `cythera/cythera_data_viewer.html` | **404** — it is `explorer.html` now |
| `cythera/colorcyclecanvas.html` | **404** — it is `canvas.html` now |
| `cythera/resource_fork_browser.html` | **404** — retired; its decoders were folded into the viewer's *Resource Fork (all types)* gallery |
| `cythera/mobile.html` | 200 |

`index.html` and `README.md` are corrected, and the retired browser's entry is dropped rather than repointed — the viewer already reaches the same decoders.

`CLAUDE.md` said the links "did not change" when the tools left for their own repository. That was true the day it was written, and it is what made this invisible afterwards; it now says the filenames on the other side move and nothing here notices, with the three names as the worked example.

Nothing else is touched. Worth knowing but left alone: `cythera-preview/` holds an undocumented copy of the old viewer plus its `js/` and `res/`, which the other repository has since moved well past — I did not want to delete a directory nobody asked me about, but it is probably stale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXc3J6AXiCk4rgSQpdGL4X)_